### PR TITLE
fix(gui): アプリケーション起動時の初期化エラーを修正

### DIFF
--- a/src/gui/base_frame_gui.py
+++ b/src/gui/base_frame_gui.py
@@ -10,7 +10,6 @@ class BaseFrameGUI(tk.Frame):
         self.master = master
         self.app = app_instance
         self.current_theme_name = self.app.settings_manager.get_setting("theme")
-        self.apply_theme(self.current_theme_name)
 
     def apply_theme(self, theme_name):
         theme = theme_manager.apply_theme(self.master, theme_name)

--- a/src/gui/fixed_phrases_window.py
+++ b/src/gui/fixed_phrases_window.py
@@ -26,7 +26,7 @@ class FixedPhrasesFrame(BaseFrameGUI):
             components_dir.mkdir(exist_ok=True)
             
             # リストコンポーネントの作成と配置
-            self.list_component = PhraseListComponent(self, self.app.fixed_phrases_manager)
+            self.list_component = PhraseListComponent(self, self.app)
             self.list_component.pack(fill=tk.BOTH, expand=True)
 
             # 編集コンポーネントの作成と配置

--- a/src/gui/main_gui.py
+++ b/src/gui/main_gui.py
@@ -81,6 +81,8 @@ class ClipWatcherGUI(BaseFrameGUI):
         self.fixed_phrases_frame = FixedPhrasesFrame(fixed_phrases_tab_frame, self.app)
         self.fixed_phrases_frame.pack(fill=tk.BOTH, expand=True)
 
+        self.apply_theme(self.current_theme_name)
+
     def _on_history_select(self, event):
         selected_indices = self.history_listbox.curselection()
         self.clipboard_text_widget.config(state=tk.NORMAL)


### PR DESCRIPTION
アプリケーション起動時に発生していた2つの `AttributeError` を修正しました。

1.  `ClipWatcherGUI` の初期化中に `current_clipboard_frame` が存在しないエラー
    -   原因: 基底クラス `BaseFrameGUI` が、派生クラスのUI要素作成前にテーマ適用メソッドを呼び出していた。
    -   対策: `apply_theme` の呼び出しを `BaseFrameGUI` のコンストラクタから削除し、`ClipWatcherGUI` のコンストラクタの最後に移動しました。

2.  `FixedPhrasesFrame` の初期化中に `settings_manager` が存在しないエラー
    -   原因: `PhraseListComponent` に、アプリケーションインスタンスではなく `FixedPhrasesManager` が渡されていた。
    -   対策: `PhraseListComponent` の初期化時に、完全なアプリケーションインスタンスを渡すように修正しました。