### PR TITLE
Refactor/general

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/review/review_2026_05_28_architecture_review.md
+++ b/review/review_2026_05_28_architecture_review.md
@@ -1,0 +1,147 @@
+# ClipWatcher アーキテクチャレビュー (2026-05-28)
+
+本ドキュメントでは、直近で実施されたSQLiteデータベースへの移行、メタ定型文管理機能の追加、および `refactor/general` ブランチで進められているUI・エラーハンドリング標準化を踏まえた、ClipWatcherプロジェクト全体のアーキテクチャ設計・実装に対するレビュー結果をまとめます。
+
+---
+
+## 1. 直近で改善・強化された点（Strengths & Recent Improvements）
+
+直近のアップデートおよびリファクタリングにより、アプリケーションの信頼性、保守性、およびユーザー体験（UX）が劇的に向上しました。
+
+- **SQLiteデータベース移行によるデータ整合性の確保**:
+  これまでの JSON ファイルベースの履歴管理から SQLite データベースへの移行が完了しました。
+  - `DatabaseManager` と各DAO (`ClipboardHistoryDAO`, `CategoryDAO`, `MetaPhraseDAO`)・DTOを仲介する堅牢なデータアクセスレイヤー（DAO/DTOパターン）が構築されています。
+  - `PRAGMA foreign_keys = ON` が確実に実行され、データベースの外部キー制約（`ON DELETE CASCADE`）の恩恵により、カテゴリ削除時に紐づくメタ定型文が連動して自動削除されるなど、データ不整合が起きない仕組みになっています。
+  - スレッド排他制御 (`threading.Lock`) がDAO層に適切に組み込まれており、SQLiteのマルチスレッドアクセスによる競合やロックエラーを防いでいます。
+
+- **GUI基底クラス (BaseFrameGUI, BaseToplevelGUI) への統一**:
+  メタ定型文管理画面 (`meta_management_window.py`) のリファクタリングにより、主要なGUIコンポーネントがプロジェクト共通の基底クラスを継承するようになりました。
+  - Tkinterのカスタムテーマやダークモード設定が起動時に自動かつ一貫して適用されるようになり、トーンが完璧に統一されました。
+  - 重複しがちだったウィジェット生成ロジックの共通化や、親ウインドウ参照の整理が進んでいます。
+
+- **例外処理とロギングの標準化**:
+  - 全てのデータベース書き込みやファイル操作を伴うイベントハンドラーに `try-except` 保護が導入されました。
+  - 例外発生時にはプロジェクト標準のエラーハンドラーである `log_and_show_error` が呼び出され、詳細なスタックトレースをログに残しつつユーザーに安全なエラーダイアログを表示する設計になりました。
+  - ユーザーの操作ログ（追加、編集、削除、コピー等）に他画面と同様の丁寧な日本語でのロギング (`logger.info`) が追加され、トラブルシューティング時のトレーサビリティが大幅に向上しました。
+
+---
+
+## 2. 依然として残る課題・改善提案（Areas for Improvement）
+
+さらなる疎結合化と全般的なリファクタリング（`refactor/general` ブランチでの継続作業）に向けて、以下のアーキテクチャ上の課題を提示します。
+
+### 2.1 ClipboardMonitor の単一責任原則 (SRP) 違反の継続
+SQLiteへの移行により「データ永続化」のロジック自体はDAOへ分離されましたが、依然として `ClipboardMonitor` クラスが以下の複数の大きな責務を負っています。
+1. **OSのクリップボード監視** (`_monitor_clipboard`, `_get_clipboard_content`, `_check_clipboard`)
+2. **履歴（History）のメモリ上でのリスト状態管理** (`self.history` の保持)
+3. **履歴に対する操作インターフェースの提供** (`pin_item_by_id`, `delete_history_item_by_id`, `clear_history`, `import_history` 等)
+
+**提案**:
+- メモリ上の履歴リスト状態管理と操作インターフェースを提供する **`HistoryService`** または **`HistoryManager`** を完全に分離すべきです。
+- `ClipboardMonitor` は純粋に「OSクリップボードを監視して変更があればイベントを発火する」という本来の責任に集中させます。履歴の追加や削除、ピン留めなどのドメインロジックは新設した `HistoryService` に移譲することで、監視とドメインロジックが疎結合になり、単体テストが極めて容易になります。
+
+### 2.2 後方互換用ダミーメソッドの残存
+`ClipboardMonitor` 内に、JSON永続化時代の名残りである `_load_history_from_file` や `save_history_to_file` が中身のないダミー実装として残されています。これは呼び出し側コードとの密結合が残っていることを示しています。
+
+**提案**:
+- `MainApplication` や他のコンポーネントにおける `monitor.save_history_to_file()` などの古いメソッド呼び出し箇所をすべて調査し、これらを完全に廃止・削除します。
+- 使用されていないファイルパス関連 of 引数（`history_file_path` など）もコンストラクタから整理すべきです。
+
+### 2.3 EventDispatcher によるイベント駆動のさらなる推進
+現在、`ClipboardMonitor` からのUI更新通知は、GUIから渡された `update_callback` の直接呼び出し (`self.update_callback(...)`) によって行われています。
+プロジェクト内には強力な Pub/Sub メカニズムである `EventDispatcher` が既に導入されています。
+
+**提案**:
+- コールバックを直接渡し合う緊密な設計から脱却し、クリップボード更新や履歴の変更を `EventDispatcher` のイベント（例: `CLIPBOARD_UPDATED`, `HISTORY_CHANGED`）としてブロードキャストします。
+- GUI側（`MainGUI` や各コンポーネント）がこのイベントを購読 (`subscribe`) して自発的に描画を更新するように変更することで、監視コア層とGUI層が完全に疎結合化されます。
+
+### 2.4 クラスの紐づき（依存関係）の現状とあるべき姿
+現在、`ClipboardMonitor` を中心とするクラスの紐づき（依存関係）は密結合になっており、これがテスト容易性の低下や変更時の影響範囲拡大の原因となっています。
+
+#### 【現状のクラス紐づき (Before)】
+```mermaid
+classDiagram
+    class MainApplication {
+        +db_manager: DatabaseManager
+        +event_dispatcher: EventDispatcher
+        +monitor: ClipboardMonitor
+        +gui: MainGUI
+    }
+    class ClipboardMonitor {
+        -db_manager: DatabaseManager
+        -event_dispatcher: EventDispatcher
+        -tk_root: tk.Tk
+        +update_callback: Callable
+        +history: list
+        +get_history()
+        +update_clipboard()
+    }
+    class MainGUI {
+        +app: MainApplication
+    }
+    class DatabaseManager {
+        +history_dao: ClipboardHistoryDAO
+    }
+    MainApplication --> ClipboardMonitor : 保持 & 依存
+    MainApplication --> MainGUI : 保持
+    ClipboardMonitor --> DatabaseManager : 直接依存してデータ書き出し・読み込み
+    MainGUI --> ClipboardMonitor : update_callbackによる密な状態同期
+```
+* **課題点**: 
+  - `ClipboardMonitor` が `DatabaseManager` に直接依存しており、OS監視とデータ永続化が一体化しています。
+  - `MainGUI` が `ClipboardMonitor` の `update_callback` と直接繋がっており、GUIと監視ロジックの相互依存度が高いです。
+
+#### 【推奨されるクラス紐づき (After)】
+`HistoryService` を抽出し、`EventDispatcher` による Pub/Sub パターンを推し進めた場合の理想的な紐づき設計です。
+```mermaid
+classDiagram
+    class MainApplication {
+        +db_manager: DatabaseManager
+        +event_dispatcher: EventDispatcher
+        +monitor: ClipboardMonitor
+        +history_service: HistoryService
+        +gui: MainGUI
+    }
+    class ClipboardMonitor {
+        -event_dispatcher: EventDispatcher
+        -tk_root: tk.Tk
+        +start()
+        +stop()
+    }
+    class HistoryService {
+        -db_manager: DatabaseManager
+        -event_dispatcher: EventDispatcher
+        +get_history()
+        +update_history()
+    }
+    class MainGUI {
+        -event_dispatcher: EventDispatcher
+    }
+    
+    MainApplication --> ClipboardMonitor : 保持
+    MainApplication --> HistoryService : 保持
+    MainApplication --> MainGUI : 保持
+    ClipboardMonitor --> EventDispatcher : クリップボード変更時にイベント通知\n(CLIPBOARD_CHANGED)
+    HistoryService --> EventDispatcher : クリップボード変更イベントを購読\n(DBへ保存 & HISTORY_UPDATEDイベント発火)
+    MainGUI --> EventDispatcher : HISTORY_UPDATEDイベントを購読して描画更新
+    HistoryService --> DatabaseManager : 依存 (データアクセス)
+```
+* **改善効果**:
+  - `ClipboardMonitor` はデータベースや履歴操作、GUIのコールバックから完全に解放され、純粋にOS監視とイベント通知のみを担当する「薄い監視レイヤー」となります。
+  - 履歴の操作ロジックは `HistoryService` にカプセル化され、GUIは `EventDispatcher` を介してのみデータを購読するため、クラス間の紐づきが極めて疎結合になり、単体テストや部品の差し替えが容易になります。
+
+---
+
+## 3. `refactor/general` ブランチにおける次のステップ
+
+今後 `refactor/general` ブランチでアプリ全般のリファクタリングを進めていくにあたり、リスクが低く効果の高い以下の優先順位での実行を推奨します。
+
+1. **イベント駆動の強化**:
+   - `ClipboardMonitor` の `update_callback` を廃止し、`EventDispatcher` によるイベント通知に一本化する。
+2. **`HistoryService` の切り出し**:
+   - `ClipboardMonitor` から履歴の操作ロジック（ピン留め、削除、一括インポートなど）を `HistoryService` に抽出し、`ClipboardMonitor` はOS監視に専念させる。
+3. **古いダミーメソッドと無効な引数の完全クリーンアップ**:
+   - JSON永続化関連の古いメソッドおよびパス引数をコードベース全体から完全に削除する。
+
+---
+*レビュー担当: AI Assistant (Antigravity)*

--- a/review/review_2026_05_28_clipboard_ux_review.md
+++ b/review/review_2026_05_28_clipboard_ux_review.md
@@ -1,0 +1,130 @@
+# クリップボード使用感（UX）に関する不具合調査＆改善レビュー報告書
+
+作成日: 2026年5月28日  
+対象モジュール: `HistoryListComponent`, `ClipWatcherGUI`, `ClipboardMonitor`
+
+---
+
+## 1. 概要 (Overview)
+現在のクリップボード履歴機能において、ユーザーが快適にアプリを使用する上で極めて重大な以下の2つのUX低下（使用感の悪さ）が発生しています。
+1. **スクロール位置の強制リセット**: 履歴リストをスクロールして過去の履歴を閲覧しようとしても、すぐにスクロールバーが一番上に戻されてしまう。
+2. **コピー操作および編集の阻害**: 履歴のテキストエリアから文字をコピー（ドラッグ選択）しようとしたり、テキストエリアを編集しようとしている最中に、選択状態やカーソル、フォーカスが突然吹き飛んでしまう。
+
+本ドキュメントでは、この2つの不具合の技術的な根本原因を解析し、Mermaidによるイベントシーケンス図で相互作用を視覚化するとともに、これらを完全に解消するための堅牢な改善プランを提案します。
+
+---
+
+## 2. 根本原因の解析 (Root Cause Analysis)
+
+### 原因①: リスト消去に伴うスクロールバーの強制リセット
+`HistoryListComponent`（履歴リストを表示する部品）が更新される際、毎回無条件に全要素を削除して再インサートする設計になっています。
+```python
+# src/gui/components/history_list_component.py
+def update_history(self, history: list[tuple[str, bool, float]], theme: dict[str, str]) -> None:
+    ...
+    self.listbox.delete(0, tk.END)  # 毎回すべての項目を削除
+    ...
+```
+* **仕様上の制限**: `delete(0, tk.END)` が実行されてリストボックスの要素数が一瞬でも `0` になった瞬間、Tkinterは内部のスクロール領域（高さ）を失います。このため、**スクロールバーの位置が強制的に一番上（位置 0.0）にリセット**されます。
+* 後方で `yview_moveto(scroll_pos[0])` による復元を試みていますが、要素数が一時的にゼロになったことでスクロールバー自体がガタつき、不自然に一番上に戻る不快な視覚的挙動が発生します。
+
+---
+
+### 原因②: リストクリア時の不要なイベント連鎖（イベント・カスケード）
+最も深刻なのは、リスト消去時に発生する「イベントの負の連鎖」です。
+
+1. リストボックスの全消去 (`delete`) により、現在選択されているアイテムが一時的に消滅し、選択数が `0` になります。
+2. これを検知したTkinterは、**ユーザーが操作していないにもかかわらず、内部で `<<ListboxSelect>>` イベントを自動的に発火**します。
+3. このイベントを親である `ClipWatcherGUI` (`main_gui.py`) が受信すると、イベントハンドラー `_on_history_selection_changed` が動作します。
+4. 選択数が `0` であるため、メインGUIは**「ユーザーが選択を解除した」と誤認**し、上のテキストエリア (`clipboard_text_widget`) を `delete("1.0", "end")` でクリアした上で、最新のクリップボード文字列で上書きします。
+5. このリフレッシュが、0.5秒おきのクリップボードチェック等でバックグラウンド実行されるため、ユーザーが上のテキストエリアでコピー（ドラッグ選択）しようとしている最中に、**テキストが勝手に消去・再挿入され、フォーカスや選択範囲がすべて吹き飛びます**。
+
+---
+
+## 3. 不具合発生のシーケンス図 (Visualizing the Issue)
+
+以下は、定期的な監視処理によってリストが更新され、不要なイベントが連鎖してテキストエリアが強制リセットされる様子を示したシーケンス図です。
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CM as ClipboardMonitor / HistoryService
+    participant HLC as HistoryListComponent (Listbox)
+    participant MG as MainGUI (TextWidget)
+    
+    Note over CM: 0.5秒ごとにクリップボードを監視
+    CM->>MG: update_clipboard_display() [定期GUI更新コールバック]
+    MG->>HLC: update_history() [再描画呼び出し]
+    Note over HLC: 現在のスクロール位置 (yview) と選択インデックスを保持
+    
+    HLC->>HLC: delete(0, tk.END) [リスト要素 of 全消去]
+    Note over HLC: 要素が0件になり、スクロール位置が一瞬で強制的に一番上(0.0)にリセット！
+    
+    activate HLC
+    HLC-->>MG: <<ListboxSelect>> イベント発火 [要素数0による意図しない自動トリガー]
+    deactivate HLC
+    
+    activate MG
+    MG->>MG: _on_history_selection_changed() [イベントハンドラ実行]
+    Note over MG: 選択数0のため「選択解除」と誤判定
+    MG->>MG: clipboard_text_widget.delete(1.0, tk.END) [テキストエリア強制クリア]
+    MG->>MG: clipboard_text_widget.insert(..., current_content) [最新データ再挿入]
+    Note over MG: ユーザーがドラッグ選択中であってもフォーカスや選択範囲が全消去される！
+    deactivate MG
+    
+    HLC->>HLC: listbox.insert(tk.END, items...) [要素の再インサート]
+    HLC->>HLC: selection_set(index) [選択の復元]
+    HLC->>HLC: yview_moveto(scroll_pos) [スクロール位置の復元を試みるがガタつき発生]
+```
+
+---
+
+## 4. 解決策の提案 (Proposed Solutions)
+
+この使用感の不具合を完全に解消し、プレミアムで滑らかな操作感を実現するために、以下の3つの安全な対策を提案します。
+
+### 対策[1] : 履歴データに変化がない場合は再描画を完全にスキップする (最重要)
+履歴リストが更新される際、渡された新しい履歴配列と、現在表示されている履歴配列（`self.displayed_history`）を比較し、**データに全く変更がない場合は、リストボックスの全削除・挿入処理を完全にバイパス（早期リターン）**します。
+これにより、ユーザーが過去の履歴をスクロールして見ている間、リストボックスは全く干渉されず、スクロール位置が勝手に戻ることは100%なくなります。
+
+```python
+# 改善後のイメージ
+def update_history(self, history: list[tuple[str, bool, float]], theme: dict[str, str]) -> None:
+    # 完全に同じデータなら何もしない（スクロールと選択状態が完璧に保護される）
+    if self.displayed_history == history:
+        return
+    ...
+```
+
+---
+
+### 対策[2] : リスト更新中のガードフラグの導入
+リストの再構築（`delete` から `insert`）を行っている間、一時的な状態ガードフラグ（`self._updating_history = True`）を導入します。
+このフラグが有効な間は `<<ListboxSelect>>` のディスパッチ処理をスキップさせることで、再描画の瞬間の「要素数ゼロ」による誤認識イベント連鎖を完全に遮断します。
+
+```python
+# 改善後のイメージ
+def _on_history_select(self, event: tk.Event) -> None:
+    if self._updating_history:  # 再描画中のイベントは外部に通知しない
+        return
+    self.app.event_dispatcher.dispatch("HISTORY_SELECTION_CHANGED", ...)
+```
+
+---
+
+### 対策[3] : テキストエリアの上書き防止（差分チェック）
+メインGUIがテキストエリアを更新する際、無条件で全消去・再挿入するのではなく、**現在すでに入力されているテキストと、新しく挿入しようとしているテキストが同一である場合は、クリア＆インサート処理を実行しない**ようにガードを入れます。
+これにより、同じ文字列を表示している限りテキストエリアは全く干渉されず、ユーザーのドラッグ選択、フォーカス、カーソル位置が一切リセットされなくなります。
+
+```python
+# 改善後のイメージ
+current_area_text = self.clipboard_text_widget.get("1.0", "end-1c")
+if current_area_text != new_insert_content:  # 差分があるときだけ上書き
+    self.clipboard_text_widget.delete(1.0, tk.END)
+    self.clipboard_text_widget.insert(tk.END, new_insert_content)
+```
+
+---
+
+## 5. まとめ (Summary)
+これらの改善を適用することで、0.5秒ごとのバックグラウンドポーリングが行われている状態でも、UIは「見えない静寂」を保ち、データが本当に変化した瞬間だけ滑らかにリストが更新されるようになります。ユーザーのスクロール操作やコピー操作への干渉は完全にゼロになり、デスクトップユーティリティとしての品質が飛躍的に向上します。

--- a/review/review_2026_05_28_clipboard_ux_review.md
+++ b/review/review_2026_05_28_clipboard_ux_review.md
@@ -90,9 +90,12 @@ sequenceDiagram
 ```python
 # 改善後のイメージ
 def update_history(self, history: list[tuple[str, bool, float]], theme: dict[str, str]) -> None:
-    # 完全に同じデータなら何もしない（スクロールと選択状態が完璧に保護される）
-    if self.displayed_history == history:
+    # 履歴データと現在のテーマ（色設定）が両方完全に同じなら何もしない
+    # ※テーマ変更時（ダーク/ライト切り替え時）は再描画してピン留め背景色などを適用する必要があるため、テーマの比較も必須です。
+    if getattr(self, "displayed_history", None) == history and getattr(self, "current_theme", None) == theme:
         return
+    
+    self.current_theme = theme
     ...
 ```
 
@@ -119,7 +122,12 @@ def _on_history_select(self, event: tk.Event) -> None:
 ```python
 # 改善後のイメージ
 current_area_text = self.clipboard_text_widget.get("1.0", "end-1c")
-if current_area_text != new_insert_content:  # 差分があるときだけ上書き
+
+# ① もしユーザーがテキストエリア内の文字を「ドラッグ選択中」であれば、上書きを強制キャンセルする（コピー操作の保護）
+is_text_selected = bool(self.clipboard_text_widget.tag_ranges(tk.SEL))
+
+# ② テキストに差分がある、かつユーザーが選択操作中でない場合のみ上書きする
+if current_area_text != new_insert_content and not is_text_selected:
     self.clipboard_text_widget.delete(1.0, tk.END)
     self.clipboard_text_widget.insert(tk.END, new_insert_content)
 ```

--- a/src/core/app_main.py
+++ b/src/core/app_main.py
@@ -49,7 +49,8 @@ class MainApplication(BaseApplication):
 
         self.gui = ClipWatcherGUI(master, self)
 
-        self.monitor.set_gui_update_callback(self.update_gui)
+        # コールバックではなく、EventDispatcherによるイベント駆動（Pub/Sub）でGUIの更新を受け取ります
+        self.event_dispatcher.subscribe("HISTORY_UPDATED", self._on_history_updated_event)
         self.monitor.set_error_callback(self.show_error_message)
 
         self._rebuild_menu(event=None) # Call with dummy event
@@ -93,6 +94,12 @@ class MainApplication(BaseApplication):
     def update_gui(self, current_content: str, history: list[tuple[str, bool, float]]) -> None:
         """Wrapper to pass sort order to the GUI."""
         self.gui.update_clipboard_display(current_content, history, self.history_sort_ascending)
+
+    def _on_history_updated_event(self, data: dict[str, Any]) -> None:
+        """履歴更新イベント（HISTORY_UPDATED）受信時のハンドラー。"""
+        last_content = data.get("last_content", "")
+        history = data.get("history", [])
+        self.update_gui(last_content, history)
 
     def on_focus_in(self, event: tk.Event | None = None) -> None:
         self.reassert_topmost()

--- a/src/core/app_main.py
+++ b/src/core/app_main.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from src.core.config.settings_manager import SettingsManager
     from src.core.event_dispatcher import EventDispatcher
     from src.core.fixed_phrases_manager import FixedPhrasesManager
+    from src.core.history_service import HistoryService
     from src.core.plugin_manager import PluginManager
     from src.db.database_manager import DatabaseManager
     from src.gui.theme_manager import ThemeManager
@@ -25,13 +26,14 @@ if TYPE_CHECKING:
 
 
 class MainApplication(BaseApplication):
-    def __init__(self, master: tk.Tk, settings_manager: SettingsManager, db_manager: DatabaseManager, monitor: ClipboardMonitor, fixed_phrases_manager: FixedPhrasesManager, plugin_manager: PluginManager, event_dispatcher: EventDispatcher, theme_manager: ThemeManager, translator: Translator, app_status: Any) -> None:
+    def __init__(self, master: tk.Tk, settings_manager: SettingsManager, db_manager: DatabaseManager, history_service: HistoryService, monitor: ClipboardMonitor, fixed_phrases_manager: FixedPhrasesManager, plugin_manager: PluginManager, event_dispatcher: EventDispatcher, theme_manager: ThemeManager, translator: Translator, app_status: Any) -> None:
         super().__init__()
         self.master = master
         self.master.protocol("WM_DELETE_WINDOW", self.on_closing)
 
         self.settings_manager = settings_manager
         self.db_manager = db_manager
+        self.history_service = history_service
         self.monitor = monitor
         self.fixed_phrases_manager = fixed_phrases_manager
         self.plugin_manager = plugin_manager
@@ -61,10 +63,10 @@ class MainApplication(BaseApplication):
     def on_ready(self) -> None:
         """Called when the application is fully initialized and ready to run."""
         self._set_state(ApplicationState.READY)
-  
+
         # Populate GUI with initial history loaded from file
         self.update_gui(self.monitor.last_clipboard_data, self.monitor.get_history())
-        
+
         self.monitor.start()
         self._set_state(ApplicationState.RUNNING)
 

--- a/src/core/application_builder.py
+++ b/src/core/application_builder.py
@@ -19,6 +19,7 @@ from .plugin_manager import PluginManager
 
 if TYPE_CHECKING:
     from src.core.app_main import MainApplication
+    from src.core.history_service import HistoryService
     from src.db.database_manager import DatabaseManager
 
 logger = logging.getLogger(__name__)
@@ -29,6 +30,7 @@ class ApplicationBuilder:
     def __init__(self) -> None:
         self.settings_manager: SettingsManager | None = None
         self.db_manager: DatabaseManager | None = None
+        self.history_service: HistoryService | None = None
         self.monitor: ClipboardMonitor | None = None
         self.fixed_phrases_manager: FixedPhrasesManager | None = None
         self.plugin_manager: PluginManager | None = None
@@ -104,14 +106,31 @@ class ApplicationBuilder:
             log_and_show_error(title="エラー", message=f"テーママネージャーの初期化に失敗: {str(e)}")
             raise ConfigError(f"テーママネージャーの初期化に失敗しました: {str(e)}") from e
 
+    def with_history_service(self) -> ApplicationBuilder:
+        """履歴サービスの初期化"""
+        if not self.event_dispatcher or not self.db_manager:
+            raise ConfigError("イベントディスパッチャまたはデータベースマネージャーが初期化されていません")
+        try:
+            from src.core.history_service import HistoryService
+            # デフォルト設定から履歴数上限を取得（後でSETTINGS_CHANGEDでも同期されます）
+            limit = 50
+            if self.settings_manager:
+                limit = self.settings_manager.get_setting("history_limit", 50)
+            self.history_service = HistoryService(self.db_manager, self.event_dispatcher, history_limit=limit)
+            logger.info("履歴サービスを初期化しました")
+            return self
+        except Exception as e:
+            log_and_show_error(title="エラー", message=f"履歴サービスの初期化に失敗: {str(e)}")
+            raise ConfigError(f"履歴サービスの初期化に失敗しました: {str(e)}") from e
+
     def with_clipboard_monitor(self, master: tk.Tk, history_file_path: str) -> ApplicationBuilder:
         """クリップボードモニターの初期化"""
-        if not self.event_dispatcher or not self.app_status or not self.db_manager:
-            raise ConfigError("イベントディスパッチャ、アプリケーションステータス、またはデータベースマネージャーが初期化されていません")
+        if not self.event_dispatcher or not self.app_status or not self.db_manager or not self.history_service:
+            raise ConfigError("イベントディスパッチャ、アプリケーションステータス、データベースマネージャー、または履歴サービスが初期化されていません")
 
         try:
             win32_available = self.app_status.dependencies.win32_available
-            self.monitor = ClipboardMonitor(master, self.event_dispatcher, history_file_path, win32_available, self.db_manager)
+            self.monitor = ClipboardMonitor(master, self.event_dispatcher, history_file_path, win32_available, self.db_manager, self.history_service)
             logger.info("クリップボードモニターを初期化しました")
             return self
         except Exception as e:
@@ -142,7 +161,7 @@ class ApplicationBuilder:
 
     def build(self, master: tk.Tk) -> MainApplication:
         """アプリケーションのビルド"""
-        if not all([self.settings_manager, self.db_manager, self.monitor, self.fixed_phrases_manager, self.plugin_manager, self.event_dispatcher, self.theme_manager, self.translator, self.app_status]):
+        if not all([self.settings_manager, self.db_manager, self.history_service, self.monitor, self.fixed_phrases_manager, self.plugin_manager, self.event_dispatcher, self.theme_manager, self.translator, self.app_status]):
             raise ConfigError("必要なコンポーネントが初期化されていません")
 
         try:
@@ -151,6 +170,7 @@ class ApplicationBuilder:
                 master=master,
                 settings_manager=self.settings_manager, # type: ignore
                 db_manager=self.db_manager, # type: ignore
+                history_service=self.history_service, # type: ignore
                 monitor=self.monitor, # type: ignore
                 fixed_phrases_manager=self.fixed_phrases_manager, # type: ignore
                 plugin_manager=self.plugin_manager, # type: ignore

--- a/src/core/clipboard_monitor.py
+++ b/src/core/clipboard_monitor.py
@@ -33,7 +33,6 @@ class ClipboardMonitor:
         self.event_dispatcher = event_dispatcher
         self.win32_available = win32_available
         self.notification_manager = NotificationManager(None) # 設定はイベント経由で渡されます
-        self.update_callback: Callable[[str, list[tuple[str, bool, float]]], None] | None = None
         self.error_callback: Callable[[str, str], None] | None = None
         self._running: bool = False
         self.monitor_thread: threading.Thread | None = None
@@ -68,8 +67,6 @@ class ClipboardMonitor:
         self.history_limit = settings.get("history_limit", 50)
         self.excluded_apps = settings.get("excluded_apps", [])
         self.notification_manager.update_settings(settings)
-        # 履歴件数の制御と通知は HistoryService 側に委譲されていますが、後方互換コールバックのためにトリガー
-        self._trigger_gui_update()
 
     def set_error_callback(self, callback: Callable[[str, str], None]) -> None:
         self.error_callback = callback
@@ -96,9 +93,6 @@ class ClipboardMonitor:
 
         return exe_name.value.decode(errors="ignore")
 
-    def set_gui_update_callback(self, callback: Callable[[str, list[tuple[str, bool, float]]], None]) -> None:
-        self.update_callback = callback
-
     def update_clipboard(self, text: str) -> None:
         """プログラムでシステムクリップボードを更新し、新しいエントリとして扱います。"""
         if not text:
@@ -119,7 +113,6 @@ class ClipboardMonitor:
 
         # _check_clipboardのロジックを模倣して、履歴を直接更新します
         self.history_service.add_history_item(text)
-        self._trigger_gui_update()
 
     def _monitor_clipboard(self) -> None:
         logging.info("クリップボード監視を開始します")
@@ -200,7 +193,6 @@ class ClipboardMonitor:
             return
 
         self.history_service.add_history_item(clipboard_data)
-        self._trigger_gui_update()
 
     def _check_clipboard(self) -> None:
         try:
@@ -232,11 +224,8 @@ class ClipboardMonitor:
     def update_history_item_by_id(self, item_id: float, new_text: str) -> None:
         """Finds a history item by its ID and updates its content."""
         self.history_service.update_history_item_by_id(item_id, new_text)
-        self._trigger_gui_update()
 
-    def _trigger_gui_update(self) -> None:
-        if self.update_callback:
-            self.tk_root.after(0, self.update_callback, self.last_clipboard_data, self.get_history())
+
 
     def start(self) -> None:
         if not self._running:
@@ -265,30 +254,24 @@ class ClipboardMonitor:
 
     def clear_history(self) -> None:
         self.history_service.clear_history()
-        self._trigger_gui_update()
 
     def delete_history_item_by_id(self, item_id: float) -> None:
         """Deletes a history item using its unique ID."""
         self.history_service.delete_history_item_by_id(item_id)
-        self._trigger_gui_update()
 
     def pin_item_by_id(self, item_id: float) -> None:
         """Pins an item using its unique ID."""
         self.history_service.pin_item_by_id(item_id)
-        self._trigger_gui_update()
 
     def unpin_item_by_id(self, item_id: float) -> None:
         """Unpins an item using its unique ID."""
         self.history_service.unpin_item_by_id(item_id)
-        self._trigger_gui_update()
 
     def delete_all_unpinned_history(self) -> None:
         self.history_service.delete_all_unpinned_history()
-        self._trigger_gui_update()
 
     def import_history(self, new_history_items: list[str]) -> None:
         self.history_service.import_history(new_history_items)
-        self._trigger_gui_update()
 
     def get_filtered_history(self, query: str) -> list[tuple[str, bool, float]]:
         return self.history_service.get_filtered_history(query)

--- a/src/core/clipboard_monitor.py
+++ b/src/core/clipboard_monitor.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 import ctypes
 import ctypes.wintypes
-import json
 import logging
-import os
 import threading
 import time
 import tkinter as tk
@@ -18,47 +16,60 @@ except ImportError:
     # このモジュールはオプションであり、利用可能性は外部から注入されるフラグによって制御されます。
     pass
 
+from src.db.database_manager import DatabaseManager
+
 from .event_dispatcher import EventDispatcher
 from .notification_manager import NotificationManager
-from src.db.database_manager import DatabaseManager
-from src.db.dto import ClipboardHistoryDTO
 
 if TYPE_CHECKING:
-    pass  # For settings object
+    from src.core.history_service import HistoryService
 
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 class ClipboardMonitor:
-    def __init__(self, tk_root: tk.Tk, event_dispatcher: EventDispatcher, history_file_path: str, win32_available: bool, db_manager: DatabaseManager, history_limit: int = 50, excluded_apps: list[str] | None = None) -> None:
+    def __init__(self, tk_root: tk.Tk, event_dispatcher: EventDispatcher, history_file_path: str, win32_available: bool, db_manager: DatabaseManager, history_service: HistoryService, history_limit: int = 50, excluded_apps: list[str] | None = None) -> None:
         self.tk_root = tk_root
         self.event_dispatcher = event_dispatcher
         self.win32_available = win32_available
         self.notification_manager = NotificationManager(None) # 設定はイベント経由で渡されます
         self.update_callback: Callable[[str, list[tuple[str, bool, float]]], None] | None = None
         self.error_callback: Callable[[str, str], None] | None = None
-        self.last_clipboard_data: str = ""
         self._running: bool = False
         self.monitor_thread: threading.Thread | None = None
         self.history_file_path: str = history_file_path
         self.db_manager: DatabaseManager = db_manager
-        
+        self.history_service = history_service
+
         self.history_limit: int = history_limit
         self.excluded_apps: list[str] = excluded_apps if excluded_apps is not None else []
-        self.history: list[tuple[str, bool, float]] = self._load_history_from_db()
         self._dirty: bool = False
         self._auto_save_interval_ms: int = 5000
 
         self.event_dispatcher.subscribe("SETTINGS_CHANGED", self.on_settings_changed)
 
+    @property
+    def history(self) -> list[tuple[str, bool, float]]:
+        return self.history_service.history
+
+    @history.setter
+    def history(self, value: list[tuple[str, bool, float]]) -> None:
+        self.history_service.history = value
+
+    @property
+    def last_clipboard_data(self) -> str:
+        return self.history_service.last_clipboard_data
+
+    @last_clipboard_data.setter
+    def last_clipboard_data(self, value: str) -> None:
+        self.history_service.last_clipboard_data = value
+
     def on_settings_changed(self, settings: dict[str, Any]) -> None:
         self.history_limit = settings.get("history_limit", 50)
         self.excluded_apps = settings.get("excluded_apps", [])
         self.notification_manager.update_settings(settings)
-        if len(self.history) > self.history_limit:
-            self.history = self.history[:self.history_limit]
-            self._dirty = True
-            self._trigger_gui_update()
+        # 履歴件数の制御と通知は HistoryService 側に委譲されていますが、後方互換コールバックのためにトリガー
+        self._trigger_gui_update()
 
     def set_error_callback(self, callback: Callable[[str, str], None]) -> None:
         self.error_callback = callback
@@ -107,15 +118,7 @@ class ClipboardMonitor:
             return # クリップボードの更新に失敗した場合、履歴は変更しません
 
         # _check_clipboardのロジックを模倣して、履歴を直接更新します
-        self.last_clipboard_data = text
-
-        dto = ClipboardHistoryDTO(content=text, is_pinned=False)
-        self.db_manager.history_dao.add_item(dto)
-        self.db_manager.history_dao.cleanup_old(self.history_limit)
-        
-        self.history = self._load_history_from_db()
-
-        # GUIの更新をトリガーして新しい履歴を表示します
+        self.history_service.add_history_item(text)
         self._trigger_gui_update()
 
     def _monitor_clipboard(self) -> None:
@@ -196,13 +199,7 @@ class ClipboardMonitor:
             logging.info(f"除外アプリからのコピーのため無視: {active_process}")
             return
 
-        dto = ClipboardHistoryDTO(content=clipboard_data, is_pinned=False)
-        self.db_manager.history_dao.add_item(dto)
-        self.db_manager.history_dao.cleanup_old(self.history_limit)
-
-        self.history = self._load_history_from_db()
-
-        # GUIの更新をトリガーして新しい履歴を表示します
+        self.history_service.add_history_item(clipboard_data)
         self._trigger_gui_update()
 
     def _check_clipboard(self) -> None:
@@ -234,16 +231,8 @@ class ClipboardMonitor:
 
     def update_history_item_by_id(self, item_id: float, new_text: str) -> None:
         """Finds a history item by its ID and updates its content."""
-        db_id = int(item_id)
-        import hashlib
-        new_hash = hashlib.sha256(new_text.encode('utf-8')).hexdigest()
-        
-        success = self.db_manager.history_dao.update_content(db_id, new_text, new_hash)
-        if success:
-            if self.history and self.history[0][2] == item_id:
-                self.last_clipboard_data = new_text
-            self.history = self._load_history_from_db()
-            self._trigger_gui_update()
+        self.history_service.update_history_item_by_id(item_id, new_text)
+        self._trigger_gui_update()
 
     def _trigger_gui_update(self) -> None:
         if self.update_callback:
@@ -272,78 +261,40 @@ class ClipboardMonitor:
             self.monitor_thread.join(timeout=2)
 
     def get_history(self) -> list[tuple[str, bool, float]]:
-        # The tuple is (content, is_pinned, db_id)
-        pinned = [item for item in self.history if item[1]]
-        unpinned = [item for item in self.history if not item[1]]
-        return pinned + unpinned
+        return self.history_service.get_history()
 
     def clear_history(self) -> None:
-        self.db_manager.history_dao.clear_all()
-        self.history.clear()
-        self.last_clipboard_data = ""
+        self.history_service.clear_history()
         self._trigger_gui_update()
 
     def delete_history_item_by_id(self, item_id: float) -> None:
         """Deletes a history item using its unique ID."""
-        db_id = int(item_id)
-        success = self.db_manager.history_dao.delete_item(db_id)
-        if success:
-            self.history = self._load_history_from_db()
-            if not self.history:
-                self.last_clipboard_data = ""
-            self._trigger_gui_update()
-            logging.info(f"ID {item_id} の履歴項目を削除しました。")
-        else:
-            logging.warning(f"ID {item_id} の履歴項目が見つかりませんでした。")
+        self.history_service.delete_history_item_by_id(item_id)
+        self._trigger_gui_update()
 
     def pin_item_by_id(self, item_id: float) -> None:
         """Pins an item using its unique ID."""
-        db_id = int(item_id)
-        success = self.db_manager.history_dao.pin_item(db_id, True)
-        if success:
-            self.history = self._load_history_from_db()
-            self._trigger_gui_update()
+        self.history_service.pin_item_by_id(item_id)
+        self._trigger_gui_update()
 
     def unpin_item_by_id(self, item_id: float) -> None:
         """Unpins an item using its unique ID."""
-        db_id = int(item_id)
-        success = self.db_manager.history_dao.pin_item(db_id, False)
-        if success:
-            self.history = self._load_history_from_db()
-            self._trigger_gui_update()
+        self.history_service.unpin_item_by_id(item_id)
+        self._trigger_gui_update()
 
     def delete_all_unpinned_history(self) -> None:
-        self.db_manager.history_dao.delete_unpinned()
-        self.history = self._load_history_from_db()
+        self.history_service.delete_all_unpinned_history()
         self._trigger_gui_update()
-        logging.info("モニター: ピン留めされていないすべての履歴を削除しました。")
 
     def import_history(self, new_history_items: list[str]) -> None:
-        for item_content in reversed(new_history_items):
-            dto = ClipboardHistoryDTO(content=item_content, is_pinned=False)
-            self.db_manager.history_dao.add_item(dto)
-        self.db_manager.history_dao.cleanup_old(self.history_limit)
-        self.history = self._load_history_from_db()
+        self.history_service.import_history(new_history_items)
         self._trigger_gui_update()
 
     def get_filtered_history(self, query: str) -> list[tuple[str, bool, float]]:
-        try:
-            dtos = self.db_manager.history_dao.get_items(limit=self.history_limit, query=query)
-            return [(dto.content, dto.is_pinned, float(dto.id or 0)) for dto in dtos]
-        except Exception as e:
-            logging.error(f"履歴のフィルタリング取得中にエラーが発生しました: %s", str(e), exc_info=True)
-            return []
+        return self.history_service.get_filtered_history(query)
 
     def _load_history_from_db(self) -> list[tuple[str, bool, float]]:
-        try:
-            dtos = self.db_manager.history_dao.get_items(limit=self.history_limit)
-            history = [(dto.content, dto.is_pinned, float(dto.id or 0)) for dto in dtos]
-            if history:
-                self.last_clipboard_data = history[0][0]
-            return history
-        except Exception as e:
-            logging.error(f"データベースからの履歴読み込みに失敗しました: %s", str(e), exc_info=True)
-            return []
+        return self.history_service.load_history()
 
     def _load_history_from_file(self) -> list[tuple[str, bool, float]]:
         # 後方互換性のために残していますが、移行後は空を返します

--- a/src/core/history_service.py
+++ b/src/core/history_service.py
@@ -152,9 +152,11 @@ class HistoryService:
 
     def import_history(self, new_history_items: list[str]) -> None:
         """外部からテキスト配列を履歴項目として一括インポートします。"""
+        import time
         try:
-            for item_content in reversed(new_history_items):
-                dto = ClipboardHistoryDTO(content=item_content, is_pinned=False)
+            for i, item_content in enumerate(reversed(new_history_items)):
+                # 高速なループでも並び順が確実になるよう、わずかに時間をずらしてインサートします
+                dto = ClipboardHistoryDTO(content=item_content, is_pinned=False, created_at=time.time() - i * 0.01)
                 self.db_manager.history_dao.add_item(dto)
             self.db_manager.history_dao.cleanup_old(self.history_limit)
             self.load_history()

--- a/src/core/history_service.py
+++ b/src/core/history_service.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import hashlib
+import logging
+from typing import TYPE_CHECKING, Any
+
+from src.db.dto import ClipboardHistoryDTO
+
+if TYPE_CHECKING:
+    from src.core.event_dispatcher import EventDispatcher
+    from src.db.database_manager import DatabaseManager
+
+logger = logging.getLogger(__name__)
+
+
+class HistoryService:
+    """履歴データおよびその永続化・状態操作を管理するサービス（単一責任原則に基づく）"""
+
+    def __init__(self, db_manager: DatabaseManager, event_dispatcher: EventDispatcher, history_limit: int = 50) -> None:
+        self.db_manager = db_manager
+        self.event_dispatcher = event_dispatcher
+        self.history_limit = history_limit
+        self.last_clipboard_data: str = ""
+        self.history: list[tuple[str, bool, float]] = []
+
+        # データベースから初期履歴を読み込み
+        self.load_history()
+
+        # 設定変更イベントの購読
+        self.event_dispatcher.subscribe("SETTINGS_CHANGED", self.on_settings_changed)
+
+    def on_settings_changed(self, settings: dict[str, Any]) -> None:
+        """設定変更イベント時のハンドラー。履歴表示制限件数を更新します。"""
+        self.history_limit = settings.get("history_limit", 50)
+        if len(self.history) > self.history_limit:
+            self.history = self.history[:self.history_limit]
+            self._notify_updated()
+
+    def load_history(self) -> list[tuple[str, bool, float]]:
+        """データベースから最新の履歴データを取得し、内部状態を更新します。"""
+        try:
+            dtos = self.db_manager.history_dao.get_items(limit=self.history_limit)
+            self.history = [(dto.content, dto.is_pinned, float(dto.id or 0)) for dto in dtos]
+            if self.history:
+                self.last_clipboard_data = self.history[0][0]
+            else:
+                self.last_clipboard_data = ""
+            return self.history
+        except Exception as e:
+            logger.error(f"データベースからの履歴読み込みに失敗しました: {e}", exc_info=True)
+            return []
+
+    def get_history(self) -> list[tuple[str, bool, float]]:
+        """ピン留めされた項目が先頭に来るように並び替えた現在の履歴リストを取得します。"""
+        pinned = [item for item in self.history if item[1]]
+        unpinned = [item for item in self.history if not item[1]]
+        return pinned + unpinned
+
+    def add_history_item(self, text: str) -> None:
+        """新しいクリップボードエントリを履歴に追加します。"""
+        if not text:
+            return
+
+        # 重複チェック
+        if self.history and text == self.history[0][0]:
+            return
+
+        try:
+            dto = ClipboardHistoryDTO(content=text, is_pinned=False)
+            self.db_manager.history_dao.add_item(dto)
+            self.db_manager.history_dao.cleanup_old(self.history_limit)
+
+            self.last_clipboard_data = text
+            self.load_history()
+            self._notify_updated()
+        except Exception as e:
+            logger.error(f"履歴項目の追加に失敗しました: {e}", exc_info=True)
+
+    def update_history_item_by_id(self, item_id: float, new_text: str) -> None:
+        """指定されたIDの履歴項目のコンテンツを更新します。"""
+        db_id = int(item_id)
+        new_hash = hashlib.sha256(new_text.encode('utf-8')).hexdigest()
+
+        try:
+            success = self.db_manager.history_dao.update_content(db_id, new_text, new_hash)
+            if success:
+                if self.history and self.history[0][2] == item_id:
+                    self.last_clipboard_data = new_text
+                self.load_history()
+                self._notify_updated()
+        except Exception as e:
+            logger.error(f"履歴項目の更新に失敗しました (ID: {item_id}): {e}", exc_info=True)
+
+    def delete_history_item_by_id(self, item_id: float) -> None:
+        """指定されたIDの履歴項目を削除します。"""
+        db_id = int(item_id)
+        try:
+            success = self.db_manager.history_dao.delete_item(db_id)
+            if success:
+                self.load_history()
+                if not self.history:
+                    self.last_clipboard_data = ""
+                self._notify_updated()
+                logger.info(f"ID {item_id} の履歴項目を削除しました。")
+            else:
+                logger.warning(f"ID {item_id} の履歴項目が見つかりませんでした。")
+        except Exception as e:
+            logger.error(f"履歴項目の削除に失敗しました (ID: {item_id}): {e}", exc_info=True)
+
+    def pin_item_by_id(self, item_id: float) -> None:
+        """指定されたIDの履歴項目をピン留めします。"""
+        db_id = int(item_id)
+        try:
+            success = self.db_manager.history_dao.pin_item(db_id, True)
+            if success:
+                self.load_history()
+                self._notify_updated()
+        except Exception as e:
+            logger.error(f"履歴項目のピン留めに失敗しました (ID: {item_id}): {e}", exc_info=True)
+
+    def unpin_item_by_id(self, item_id: float) -> None:
+        """指定されたIDの履歴項目のピン留めを解除します。"""
+        db_id = int(item_id)
+        try:
+            success = self.db_manager.history_dao.pin_item(db_id, False)
+            if success:
+                self.load_history()
+                self._notify_updated()
+        except Exception as e:
+            logger.error(f"履歴項目のピン留め解除に失敗しました (ID: {item_id}): {e}", exc_info=True)
+
+    def clear_history(self) -> None:
+        """すべての履歴データを削除します。"""
+        try:
+            self.db_manager.history_dao.clear_all()
+            self.history.clear()
+            self.last_clipboard_data = ""
+            self._notify_updated()
+            logger.info("すべての履歴項目を削除しました。")
+        except Exception as e:
+            logger.error(f"履歴全体の削除に失敗しました: {e}", exc_info=True)
+
+    def delete_all_unpinned_history(self) -> None:
+        """ピン留めされていないすべての履歴データを削除します。"""
+        try:
+            self.db_manager.history_dao.delete_unpinned()
+            self.load_history()
+            self._notify_updated()
+            logger.info("ピン留めされていないすべての履歴を削除しました。")
+        except Exception as e:
+            logger.error(f"ピン留めされていない履歴の削除に失敗しました: {e}", exc_info=True)
+
+    def import_history(self, new_history_items: list[str]) -> None:
+        """外部からテキスト配列を履歴項目として一括インポートします。"""
+        try:
+            for item_content in reversed(new_history_items):
+                dto = ClipboardHistoryDTO(content=item_content, is_pinned=False)
+                self.db_manager.history_dao.add_item(dto)
+            self.db_manager.history_dao.cleanup_old(self.history_limit)
+            self.load_history()
+            self._notify_updated()
+        except Exception as e:
+            logger.error(f"履歴の一括インポートに失敗しました: {e}", exc_info=True)
+
+    def get_filtered_history(self, query: str) -> list[tuple[str, bool, float]]:
+        """検索クエリに合致する履歴項目を取得します。"""
+        try:
+            dtos = self.db_manager.history_dao.get_items(limit=self.history_limit, query=query)
+            return [(dto.content, dto.is_pinned, float(dto.id or 0)) for dto in dtos]
+        except Exception as e:
+            logger.error(f"履歴のフィルタリング取得中にエラーが発生しました: {e}", exc_info=True)
+            return []
+
+    def _notify_updated(self) -> None:
+        """履歴の状態が更新されたことをイベント経由で通知します。"""
+        self.event_dispatcher.dispatch("HISTORY_UPDATED", {
+            "last_content": self.last_clipboard_data,
+            "history": self.get_history()
+        })

--- a/src/db/dao/base_dao.py
+++ b/src/db/dao/base_dao.py
@@ -4,6 +4,7 @@ import sqlite3
 import threading
 from typing import Any
 
+
 class BaseDAO:
     """すべてのDAOクラスの共通基底クラス。排他ロックと接続の取得を管理します。"""
 

--- a/src/db/dao/category_dao.py
+++ b/src/db/dao/category_dao.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+
 from src.db.dao.base_dao import BaseDAO
 from src.db.dto import CategoryDTO
 

--- a/src/db/dao/history_dao.py
+++ b/src/db/dao/history_dao.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
-import time
 from typing import TYPE_CHECKING
 
 from src.db.dao.base_dao import BaseDAO
@@ -163,7 +162,7 @@ class ClipboardHistoryDAO(BaseDAO):
                         (excess,)
                     )
                     rows = cursor.fetchall()
-                    
+
                     if rows:
                         ids_to_delete = [row[0] for row in rows]
                         placeholders = ",".join("?" for _ in ids_to_delete)

--- a/src/db/dao/meta_phrase_dao.py
+++ b/src/db/dao/meta_phrase_dao.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+
 from src.db.dao.base_dao import BaseDAO
 from src.db.dto import MetaPhraseDTO
 

--- a/src/db/database_manager.py
+++ b/src/db/database_manager.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
@@ -25,12 +24,12 @@ class DatabaseManager:
     def __init__(self, db_path: str) -> None:
         self.db_path = db_path
         self._lock = threading.Lock()
-        
+
         # 各DAOの初期化
         self.history_dao = ClipboardHistoryDAO(db_path, self._lock)
         self.category_dao = CategoryDAO(db_path, self._lock)
         self.meta_phrase_dao = MetaPhraseDAO(db_path, self._lock)
-        
+
         logger.info("DatabaseManager を初期化します。DBパス: %s", db_path)
         self._initialize_tables()
 
@@ -55,7 +54,7 @@ class DatabaseManager:
                             created_at REAL NOT NULL
                         )
                     """)
-                    
+
                     # 2. カテゴリテーブル
                     conn.execute("""
                         CREATE TABLE IF NOT EXISTS t_category (
@@ -82,7 +81,7 @@ class DatabaseManager:
                     conn.execute("CREATE INDEX IF NOT EXISTS idx_history_hash ON t_clipboard_history(content_hash)")
                     conn.execute("CREATE INDEX IF NOT EXISTS idx_history_created ON t_clipboard_history(created_at DESC)")
                     conn.execute("CREATE INDEX IF NOT EXISTS idx_meta_phrase_category ON t_meta_phrase(category_id, sort_order)")
-                    
+
                     conn.commit()
                 logger.info("データベーステーブルおよびインデックスの初期化が完了しました。")
             except sqlite3.Error as e:
@@ -136,7 +135,7 @@ class DatabaseManager:
                         is_pinned=is_pinned,
                         created_at=created_at
                     )
-                    
+
                     # 既に存在するかチェック
                     cursor = conn.cursor()
                     cursor.execute(

--- a/src/db/dto.py
+++ b/src/db/dto.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import hashlib
 import time
+from dataclasses import dataclass
+
 
 @dataclass
 class ClipboardHistoryDTO:

--- a/src/event_handlers/__init__.py
+++ b/src/event_handlers/__init__.py
@@ -74,6 +74,7 @@ def start_app() -> None:
             .with_database(db_path) \
             .with_translator() \
             .with_theme_manager(root) \
+            .with_history_service() \
             .with_fixed_phrases_manager(fixed_phrases_file_path) \
             .with_plugin_manager() \
             .with_clipboard_monitor(root, history_file_path) \

--- a/src/gui/components/history_list_component.py
+++ b/src/gui/components/history_list_component.py
@@ -13,6 +13,8 @@ class HistoryListComponent(tk.Frame):
         super().__init__(master)
         self.app = app_instance
         self.displayed_history: list[tuple[str, bool, float]] = []  # Will store the full (content, is_pinned, timestamp) tuples
+        self.current_theme: dict[str, str] = {}
+        self._updating_history: bool = False
 
         self._create_widgets()
         self._bind_events()
@@ -45,6 +47,8 @@ class HistoryListComponent(tk.Frame):
             self.app.event_dispatcher.dispatch("HISTORY_COPY_SELECTED", item_ids) # type: ignore
 
     def _on_history_select(self, event: tk.Event) -> None:
+        if self._updating_history:
+            return
         # This event is now handled by the parent (main_gui) to update the text widget
         self.app.event_dispatcher.dispatch("HISTORY_SELECTION_CHANGED", { # type: ignore
             "selected_indices": self.listbox.curselection()
@@ -55,27 +59,36 @@ class HistoryListComponent(tk.Frame):
         return [self.displayed_history[i][2] for i in indices if 0 <= i < len(self.displayed_history)]
 
     def update_history(self, history: list[tuple[str, bool, float]], theme: dict[str, str]) -> None:
-        self.displayed_history = history  # Store the full data
+        # 履歴データとテーマが両方完全に同一の場合は何もしない（スクロールと選択状態を100%保護）
+        if self.displayed_history == history and self.current_theme == theme:
+            return
 
-        selected_indices = self.listbox.curselection()
-        scroll_pos = self.listbox.yview()
+        self._updating_history = True
+        try:
+            self.displayed_history = history  # Store the full data
+            self.current_theme = theme        # テーマを記録
 
-        self.listbox.delete(0, tk.END)
+            selected_indices = self.listbox.curselection()
+            scroll_pos = self.listbox.yview()
 
-        pinned_bg_color = theme["pinned_bg"]
+            self.listbox.delete(0, tk.END)
 
-        for i, (content, is_pinned, _timestamp) in enumerate(history):
-            display_text = content.replace('\n', ' ').replace('\r', '')
-            prefix = "📌 " if is_pinned else ""
-            # The displayed number is still based on visual order (1-based index)
-            self.listbox.insert(tk.END, f"{prefix}{i+1}. {display_text[:100]}...")
-            if is_pinned:
-                self.listbox.itemconfig(i, {'bg': pinned_bg_color})
+            pinned_bg_color = theme["pinned_bg"]
 
-        for index in selected_indices:
-            if index < self.listbox.size():
-                self.listbox.selection_set(index)
-        self.listbox.yview_moveto(scroll_pos[0])
+            for i, (content, is_pinned, _timestamp) in enumerate(history):
+                display_text = content.replace('\n', ' ').replace('\r', '')
+                prefix = "📌 " if is_pinned else ""
+                # The displayed number is still based on visual order (1-based index)
+                self.listbox.insert(tk.END, f"{prefix}{i+1}. {display_text[:100]}...")
+                if is_pinned:
+                    self.listbox.itemconfig(i, {'bg': pinned_bg_color})
+
+            for index in selected_indices:
+                if index < self.listbox.size():
+                    self.listbox.selection_set(index)
+            self.listbox.yview_moveto(scroll_pos[0])
+        finally:
+            self._updating_history = False
 
     def apply_theme(self, theme: dict[str, str]) -> None:
         self.listbox.config(bg=theme["listbox_bg"], fg=theme["listbox_fg"], selectbackground=theme["select_bg"], selectforeground=theme["select_fg"])

--- a/src/gui/main_gui.py
+++ b/src/gui/main_gui.py
@@ -268,17 +268,28 @@ class ClipWatcherGUI(BaseFrameGUI):
         else:
             self.history_component.update_history(history, theme)
 
+        # テキストエリアの上書き防止（差分チェックおよび選択操作状態の保護）
         selected_indices: tuple[int, ...] = self.history_component.listbox.curselection()
-        self.clipboard_text_widget.config(state=tk.NORMAL)
-        self.clipboard_text_widget.delete(1.0, tk.END)
+
+        # 挿入すべき新しい文字列を決定
+        new_insert_content = ""
         if selected_indices:
             index: int = selected_indices[0]
             if 0 <= index < len(self.history_data):
-                content, _, _ = self.history_data[index]
-                self.clipboard_text_widget.insert(tk.END, content)
+                new_insert_content, _, _ = self.history_data[index]
         else:
-            self.clipboard_text_widget.insert(tk.END, current_content)
+            new_insert_content = current_content
+
+        current_area_text = self.clipboard_text_widget.get("1.0", "end-1c")
+
+        # ① もしユーザーがテキストエリア内の文字を「ドラッグ選択中」であれば、上書きを強制キャンセルする（コピー操作の保護）
+        is_text_selected = bool(self.clipboard_text_widget.tag_ranges(tk.SEL))
+
+        # ② テキストに差分がある、かつユーザーが選択操作中でない場合のみ上書きする
+        if current_area_text != new_insert_content and not is_text_selected:
             self.clipboard_text_widget.config(state=tk.NORMAL)
+            self.clipboard_text_widget.delete(1.0, tk.END)
+            self.clipboard_text_widget.insert(tk.END, new_insert_content)
 
     def select_tool_tab(self, plugin_name: str) -> None:
         """Selects a notebook tab corresponding to the given plugin name."""

--- a/src/gui/windows/meta_management_window.py
+++ b/src/gui/windows/meta_management_window.py
@@ -8,7 +8,10 @@ from tkinter import messagebox, ttk
 from typing import TYPE_CHECKING, Any, cast
 
 from src.db.dto import CategoryDTO, MetaPhraseDTO
+from src.gui.base.base_frame_gui import BaseFrameGUI
+from src.gui.base.base_toplevel_gui import BaseToplevelGUI
 from src.gui.custom_widgets import CustomEntry, CustomText
+from src.utils.error_handler import log_and_show_error
 
 if TYPE_CHECKING:
     from src.core.app_main import MainApplication
@@ -16,11 +19,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-class CategoryEditDialog(tk.Toplevel):
+class CategoryEditDialog(BaseToplevelGUI):
     """カテゴリ作成/編集用のダイアログ"""
-    def __init__(self, parent: tk.Widget, app: BaseApplication, category_dto: CategoryDTO | None = None) -> None:
-        super().__init__(parent)
-        self.app = cast("MainApplication", app)
+    def __init__(self, parent: tk.Widget, app_instance: BaseApplication, category_dto: CategoryDTO | None = None) -> None:
+        super().__init__(parent, app_instance)
+        self.app: MainApplication = cast("MainApplication", app_instance)  # type: ignore
         self.category_dto = category_dto
         self.result: str | None = None
 
@@ -52,30 +55,33 @@ class CategoryEditDialog(tk.Toplevel):
         self.entry.focus_set()
 
     def on_ok(self) -> None:
-        name = self.entry.get().strip()
-        if not name:
-            messagebox.showerror("Error", "Category name cannot be empty.", parent=self)
-            return
-
-        # 重複チェック
-        categories = self.app.db_manager.category_dao.get_all()
-        for cat in categories:
-            if cat.name.lower() == name.lower():
-                # 編集時で自分自身と同じ名前ならパス
-                if self.category_dto and self.category_dto.id == cat.id:
-                    continue
-                messagebox.showerror("Error", "Category name already exists.", parent=self)
+        try:
+            name = self.entry.get().strip()
+            if not name:
+                messagebox.showerror("Error", "Category name cannot be empty.", parent=self)
                 return
 
-        self.result = name
-        self.destroy()
+            # 重複チェック
+            categories = self.app.db_manager.category_dao.get_all()
+            for cat in categories:
+                if cat.name.lower() == name.lower():
+                    # 編集時で自分自身と同じ名前ならパス
+                    if self.category_dto and self.category_dto.id == cat.id:
+                        continue
+                    messagebox.showerror("Error", "Category name already exists.", parent=self)
+                    return
+
+            self.result = name
+            self.destroy()
+        except Exception as e:
+            log_and_show_error("エラー", f"カテゴリ登録処理中にエラーが発生しました: {str(e)}", exc_info=True)
 
 
-class MetaPhraseEditDialog(tk.Toplevel):
+class MetaPhraseEditDialog(BaseToplevelGUI):
     """メタ定型文作成/編集用のダイアログ"""
-    def __init__(self, parent: tk.Widget, app: BaseApplication, phrase_dto: MetaPhraseDTO | None = None, default_category_id: int | None = None) -> None:
-        super().__init__(parent)
-        self.app = cast("MainApplication", app)
+    def __init__(self, parent: tk.Widget, app_instance: BaseApplication, phrase_dto: MetaPhraseDTO | None = None, default_category_id: int | None = None) -> None:
+        super().__init__(parent, app_instance)
+        self.app: MainApplication = cast("MainApplication", app_instance)  # type: ignore
         self.phrase_dto = phrase_dto
         self.result: tuple[str, str, int] | None = None
 
@@ -137,30 +143,34 @@ class MetaPhraseEditDialog(tk.Toplevel):
         self.title_entry.focus_set()
 
     def on_ok(self) -> None:
-        title = self.title_entry.get().strip()
-        content = self.content_text.get("1.0", "end-1c").strip()
-        cat_index = self.cat_combobox.current()
+        try:
+            title = self.title_entry.get().strip()
+            content = self.content_text.get("1.0", "end-1c").strip()
+            cat_index = self.cat_combobox.current()
 
-        if not content:
-            messagebox.showerror("Error", "Content cannot be empty.", parent=self)
-            return
-        if cat_index == -1:
-            messagebox.showerror("Error", "Please select a category.", parent=self)
-            return
+            if not content:
+                messagebox.showerror("Error", "Content cannot be empty.", parent=self)
+                return
+            if cat_index == -1:
+                messagebox.showerror("Error", "Please select a category.", parent=self)
+                return
 
-        category_id = self.categories[cat_index].id
-        if category_id is None:
-            return
+            category_id = self.categories[cat_index].id
+            if category_id is None:
+                return
 
-        self.result = (title, content, category_id)
-        self.destroy()
+            self.result = (title, content, category_id)
+            self.destroy()
+        except Exception as e:
+            log_and_show_error("エラー", f"定型文登録処理中にエラーが発生しました: {str(e)}", exc_info=True)
 
 
-class MetaManagementFrame(ttk.Frame):
+class MetaManagementFrame(BaseFrameGUI):
     """メタ管理タブのメインフレーム"""
-    def __init__(self, parent: tk.Widget, app: BaseApplication) -> None:
-        super().__init__(parent)
-        self.app = cast("MainApplication", app)
+    def __init__(self, parent: tk.Widget, app_instance: BaseApplication) -> None:
+        super().__init__(parent, app_instance)
+        self.logger = logging.getLogger(__name__)
+        self.app: MainApplication = cast("MainApplication", app_instance)  # type: ignore
         self.category_list: list[CategoryDTO] = []
         self.phrase_list: list[MetaPhraseDTO] = []
         self.selected_category_id: int | None = None # None means All
@@ -171,296 +181,355 @@ class MetaManagementFrame(ttk.Frame):
         self.app.event_dispatcher.subscribe("LANGUAGE_CHANGED", self.on_language_changed)
 
     def _create_widgets(self) -> None:
-        # 左右分割 PanedWindow
-        self.paned_window = tk.PanedWindow(self, orient=tk.HORIZONTAL, sashrelief=tk.RAISED, bg=self.app.theme_manager.get_bg_color() if hasattr(self.app.theme_manager, "get_bg_color") else "#f0f0f0")
-        self.paned_window.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
+        try:
+            # 左右分割 PanedWindow
+            self.paned_window = tk.PanedWindow(self, orient=tk.HORIZONTAL, sashrelief=tk.RAISED, bg=self.app.theme_manager.get_bg_color() if hasattr(self.app.theme_manager, "get_bg_color") else "#f0f0f0")
+            self.paned_window.pack(fill=tk.BOTH, expand=True, padx=5, pady=5)
 
-        # ================= 左側：カテゴリ管理 =================
-        self.left_frame = ttk.Frame(self.paned_window, padding="5")
-        self.paned_window.add(self.left_frame, width=180)
+            # ================= 左側：カテゴリ管理 =================
+            self.left_frame = ttk.Frame(self.paned_window, padding="5")
+            self.paned_window.add(self.left_frame, width=180)
 
-        self.category_label = ttk.Label(self.left_frame, text=self.app.translator("meta_category_title"), font=("", 10, "bold"))
-        self.category_label.pack(anchor=tk.W, pady=(0, 5))
+            self.category_label = ttk.Label(self.left_frame, text=self.app.translator("meta_category_title"), font=("", 10, "bold"))
+            self.category_label.pack(anchor=tk.W, pady=(0, 5))
 
-        # カテゴリ一覧リストボックス（美観向上のためのスタイル設定）
-        self.cat_listbox = tk.Listbox(self.left_frame, selectmode=tk.SINGLE, exportselection=False, activestyle="none")
-        self.cat_listbox.pack(fill=tk.BOTH, expand=True, pady=(0, 5))
-        self.cat_listbox.bind("<<ListboxSelect>>", self.on_category_select)
+            # カテゴリ一覧リストボックス（美観向上のためのスタイル設定）
+            self.cat_listbox = tk.Listbox(self.left_frame, selectmode=tk.SINGLE, exportselection=False, activestyle="none")
+            self.cat_listbox.pack(fill=tk.BOTH, expand=True, pady=(0, 5))
+            self.cat_listbox.bind("<<ListboxSelect>>", self.on_category_select)
 
-        # 右クリックコンテキストメニュー
-        self.cat_menu = tk.Menu(self, tearoff=0)
-        self.cat_menu.add_command(label=self.app.translator("add_category"), command=self.add_category)
-        self.cat_menu.add_command(label=self.app.translator("edit_category"), command=self.edit_category)
-        # プラットフォームに応じた右クリックのバインド (macOSはButton-2, Windows/LinuxはButton-3)
-        if sys.platform == "darwin":
-            self.cat_listbox.bind("<Button-2>", self.show_context_menu)
-        else:
-            self.cat_listbox.bind("<Button-3>", self.show_context_menu)
+            # 右クリックコンテキストメニュー
+            self.cat_menu = tk.Menu(self, tearoff=0)
+            self.cat_menu.add_command(label=self.app.translator("add_category"), command=self.add_category)
+            self.cat_menu.add_command(label=self.app.translator("edit_category"), command=self.edit_category)
+            # プラットフォームに応じた右クリックのバインド (macOSはButton-2, Windows/LinuxはButton-3)
+            if sys.platform == "darwin":
+                self.cat_listbox.bind("<Button-2>", self.show_context_menu)
+            else:
+                self.cat_listbox.bind("<Button-3>", self.show_context_menu)
 
-        # カテゴリボタン群
-        cat_btn_frame = ttk.Frame(self.left_frame)
-        cat_btn_frame.pack(fill=tk.X)
+            # カテゴリボタン群
+            cat_btn_frame = ttk.Frame(self.left_frame)
+            cat_btn_frame.pack(fill=tk.X)
 
-        self.add_cat_btn = ttk.Button(cat_btn_frame, text=self.app.translator("add"), command=self.add_category, width=6)
-        self.add_cat_btn.pack(side=tk.LEFT, padx=1, fill=tk.X, expand=True)
+            self.add_cat_btn = ttk.Button(cat_btn_frame, text=self.app.translator("add"), command=self.add_category, width=6)
+            self.add_cat_btn.pack(side=tk.LEFT, padx=1, fill=tk.X, expand=True)
 
-        self.edit_cat_btn = ttk.Button(cat_btn_frame, text=self.app.translator("edit"), command=self.edit_category, width=6)
-        self.edit_cat_btn.pack(side=tk.LEFT, padx=1, fill=tk.X, expand=True)
+            self.edit_cat_btn = ttk.Button(cat_btn_frame, text=self.app.translator("edit"), command=self.edit_category, width=6)
+            self.edit_cat_btn.pack(side=tk.LEFT, padx=1, fill=tk.X, expand=True)
 
-        self.del_cat_btn = ttk.Button(cat_btn_frame, text=self.app.translator("delete"), command=self.delete_category, width=6)
-        self.del_cat_btn.pack(side=tk.LEFT, padx=1, fill=tk.X, expand=True)
+            self.del_cat_btn = ttk.Button(cat_btn_frame, text=self.app.translator("delete"), command=self.delete_category, width=6)
+            self.del_cat_btn.pack(side=tk.LEFT, padx=1, fill=tk.X, expand=True)
 
-        # ================= 右側：定型文管理 =================
-        self.right_frame = ttk.Frame(self.paned_window, padding="5")
-        self.paned_window.add(self.right_frame, width=320)
+            # ================= 右側：定型文管理 =================
+            self.right_frame = ttk.Frame(self.paned_window, padding="5")
+            self.paned_window.add(self.right_frame, width=320)
 
-        self.phrase_label = ttk.Label(self.right_frame, text=self.app.translator("meta_phrase_title"), font=("", 10, "bold"))
-        self.phrase_label.pack(anchor=tk.W, pady=(0, 5))
+            self.phrase_label = ttk.Label(self.right_frame, text=self.app.translator("meta_phrase_title"), font=("", 10, "bold"))
+            self.phrase_label.pack(anchor=tk.W, pady=(0, 5))
 
-        # 定型文一覧 Treeview
-        tree_scroll = ttk.Scrollbar(self.right_frame, orient="vertical")
-        tree_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+            # 定型文一覧 Treeview
+            tree_scroll = ttk.Scrollbar(self.right_frame, orient="vertical")
+            tree_scroll.pack(side=tk.RIGHT, fill=tk.Y)
 
-        self.phrase_tree = ttk.Treeview(self.right_frame, columns=("title", "content"), show="headings", yscrollcommand=tree_scroll.set)
-        self.phrase_tree.pack(fill=tk.BOTH, expand=True, pady=(0, 5))
-        tree_scroll.config(command=self.phrase_tree.yview)
+            self.phrase_tree = ttk.Treeview(self.right_frame, columns=("title", "content"), show="headings", yscrollcommand=tree_scroll.set)
+            self.phrase_tree.pack(fill=tk.BOTH, expand=True, pady=(0, 5))
+            tree_scroll.config(command=self.phrase_tree.yview)
 
-        # ヘッダー設定（ヘッダーとデータのアライメントを左揃えで統一）
-        self.phrase_tree.heading("title", text=self.app.translator("phrase_title_label"), anchor=tk.W)
-        self.phrase_tree.heading("content", text=self.app.translator("phrase_content_label"), anchor=tk.W)
-        self.phrase_tree.column("title", width=100, anchor=tk.W)
-        self.phrase_tree.column("content", width=220, anchor=tk.W)
+            # ヘッダー設定（ヘッダーとデータのアライメントを左揃えで統一）
+            self.phrase_tree.heading("title", text=self.app.translator("phrase_title_label"), anchor=tk.W)
+            self.phrase_tree.heading("content", text=self.app.translator("phrase_content_label"), anchor=tk.W)
+            self.phrase_tree.column("title", width=100, anchor=tk.W)
+            self.phrase_tree.column("content", width=220, anchor=tk.W)
 
-        self.phrase_tree.bind("<Double-1>", self.on_phrase_double_click)
+            self.phrase_tree.bind("<Double-1>", self.on_phrase_double_click)
 
-        # 定型文ボタン群
-        phrase_btn_frame = ttk.Frame(self.right_frame)
-        phrase_btn_frame.pack(fill=tk.X)
+            # 定型文ボタン群
+            phrase_btn_frame = ttk.Frame(self.right_frame)
+            phrase_btn_frame.pack(fill=tk.X)
 
-        self.copy_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("copy"), command=self.copy_selected_phrase)
-        self.copy_phrase_btn.pack(side=tk.LEFT, padx=2)
+            self.copy_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("copy"), command=self.copy_selected_phrase)
+            self.copy_phrase_btn.pack(side=tk.LEFT, padx=2)
 
-        self.add_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("add"), command=self.add_phrase)
-        self.add_phrase_btn.pack(side=tk.LEFT, padx=2)
+            self.add_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("add"), command=self.add_phrase)
+            self.add_phrase_btn.pack(side=tk.LEFT, padx=2)
 
-        self.edit_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("edit"), command=self.edit_phrase)
-        self.edit_phrase_btn.pack(side=tk.LEFT, padx=2)
+            self.edit_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("edit"), command=self.edit_phrase)
+            self.edit_phrase_btn.pack(side=tk.LEFT, padx=2)
 
-        self.del_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("delete"), command=self.delete_phrase)
-        self.del_phrase_btn.pack(side=tk.LEFT, padx=2)
+            self.del_phrase_btn = ttk.Button(phrase_btn_frame, text=self.app.translator("delete"), command=self.delete_phrase)
+            self.del_phrase_btn.pack(side=tk.LEFT, padx=2)
+
+            self.logger.info("メタ定型文管理フレームを初期化しました")
+        except Exception as e:
+            self.log_and_show_error("エラー", f"メタ定型文管理フレームの初期化中にエラーが発生しました: {str(e)}", exc_info=True)
+            raise
 
     def refresh_categories(self) -> None:
         """データベースからカテゴリ一覧を取得し、リストボックスを更新します。"""
-        self.cat_listbox.delete(0, tk.END)
+        try:
+            self.cat_listbox.delete(0, tk.END)
 
-        # すべて特殊項目を追加（左側余白として半角スペースを追加）
-        all_text = self.app.translator("all_categories")
-        self.cat_listbox.insert(tk.END, f"  {all_text}")
+            # すべて特殊項目を追加（左側余白として半角スペースを追加）
+            all_text = self.app.translator("all_categories")
+            self.cat_listbox.insert(tk.END, f"  {all_text}")
 
-        self.category_list = self.app.db_manager.category_dao.get_all()
-        for cat in self.category_list:
-            self.cat_listbox.insert(tk.END, f"  {cat.name}")
+            self.category_list = self.app.db_manager.category_dao.get_all()
+            for cat in self.category_list:
+                self.cat_listbox.insert(tk.END, f"  {cat.name}")
 
-        # 選択状態を復元
-        if self.selected_category_id is None:
-            self.cat_listbox.selection_set(0)
-        else:
-            found = False
-            for idx, cat in enumerate(self.category_list):
-                if cat.id == self.selected_category_id:
-                    self.cat_listbox.selection_set(idx + 1)
-                    found = True
-                    break
-            if not found:
-                self.selected_category_id = None
+            # 選択状態を復元
+            if self.selected_category_id is None:
                 self.cat_listbox.selection_set(0)
+            else:
+                found = False
+                for idx, cat in enumerate(self.category_list):
+                    if cat.id == self.selected_category_id:
+                        self.cat_listbox.selection_set(idx + 1)
+                        found = True
+                        break
+                if not found:
+                    self.selected_category_id = None
+                    self.cat_listbox.selection_set(0)
 
-        self.refresh_phrases()
+            self.refresh_phrases()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"カテゴリ一覧の更新中にエラーが発生しました: {str(e)}", exc_info=True)
 
     def refresh_phrases(self) -> None:
         """現在選択されているカテゴリに属する定型文を表示します。"""
-        for item in self.phrase_tree.get_children():
-            self.phrase_tree.delete(item)
+        try:
+            for item in self.phrase_tree.get_children():
+                self.phrase_tree.delete(item)
 
-        self.phrase_list = self.app.db_manager.meta_phrase_dao.get_by_category(self.selected_category_id)
-        for phrase in self.phrase_list:
-            # プレビュー表示用
-            preview_content = phrase.content.replace("\n", " ")
-            display_title = phrase.title if phrase.title.strip() else self.app.translator("no_title")
-            self.phrase_tree.insert("", tk.END, iid=str(phrase.id), values=(display_title, preview_content))
+            self.phrase_list = self.app.db_manager.meta_phrase_dao.get_by_category(self.selected_category_id)
+            for phrase in self.phrase_list:
+                # プレビュー表示用
+                preview_content = phrase.content.replace("\n", " ")
+                display_title = phrase.title if phrase.title.strip() else self.app.translator("no_title")
+                self.phrase_tree.insert("", tk.END, iid=str(phrase.id), values=(display_title, preview_content))
+        except Exception as e:
+            self.log_and_show_error("エラー", f"定型文一覧の更新中にエラーが発生しました: {str(e)}", exc_info=True)
 
     def on_category_select(self, event: tk.Event | None = None) -> None:
-        selection = self.cat_listbox.curselection()
-        if not selection:
-            return
+        try:
+            selection = self.cat_listbox.curselection()
+            if not selection:
+                return
 
-        idx = selection[0]
-        if idx == 0:
-            self.selected_category_id = None
-        else:
-            self.selected_category_id = self.category_list[idx - 1].id
+            idx = selection[0]
+            if idx == 0:
+                self.selected_category_id = None
+            else:
+                self.selected_category_id = self.category_list[idx - 1].id
 
-        self.refresh_phrases()
+            self.refresh_phrases()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"カテゴリ選択処理中にエラーが発生しました: {str(e)}", exc_info=True)
 
     # ================= カテゴリ操作 =================
     def add_category(self) -> None:
-        dialog = CategoryEditDialog(self, self.app)
-        self.wait_window(dialog)
-        if dialog.result:
-            dto = CategoryDTO(name=dialog.result)
-            self.app.db_manager.category_dao.add(dto)
-            self.refresh_categories()
+        try:
+            dialog = CategoryEditDialog(self, self.app)
+            self.wait_window(dialog)
+            if dialog.result:
+                dto = CategoryDTO(name=dialog.result)
+                new_id = self.app.db_manager.category_dao.add(dto)
+                if new_id != -1:
+                    self.logger.info("カテゴリ '%s' (ID: %d) を追加しました", dialog.result, new_id)
+                self.refresh_categories()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"カテゴリの追加中にエラーが発生しました: {str(e)}", exc_info=True)
 
     def edit_category(self) -> None:
-        selection = self.cat_listbox.curselection()
-        if not selection or selection[0] == 0:
-            return
-
-        idx = selection[0]
-        target_cat = self.category_list[idx - 1]
-
-        dialog = CategoryEditDialog(self, self.app, target_cat)
-        self.wait_window(dialog)
-        if dialog.result:
-            target_cat.name = dialog.result
-            self.app.db_manager.category_dao.update(target_cat)
-            self.refresh_categories()
-
-    def delete_category(self) -> None:
-        selection = self.cat_listbox.curselection()
-        if not selection or selection[0] == 0:
-            return
-
-        idx = selection[0]
-        target_cat = self.category_list[idx - 1]
-        cat_id = target_cat.id
-        if cat_id is None:
-            return
-
-        # セーフガード: カテゴリ内の定型文件数チェック
-        phrase_count = self.app.db_manager.category_dao.get_meta_phrase_count(cat_id)
-        if phrase_count > 0:
-            msg = self.app.translator("confirm_category_delete_msg").format(count=phrase_count)
-            confirm = messagebox.askyesno(
-                self.app.translator("confirm_category_delete_title"),
-                msg,
-                parent=self
-            )
-            if not confirm:
+        try:
+            selection = self.cat_listbox.curselection()
+            if not selection or selection[0] == 0:
                 return
 
-        self.app.db_manager.category_dao.delete(cat_id)
-        self.selected_category_id = None
-        self.refresh_categories()
+            idx = selection[0]
+            target_cat = self.category_list[idx - 1]
+
+            dialog = CategoryEditDialog(self, self.app, target_cat)
+            self.wait_window(dialog)
+            if dialog.result:
+                old_name = target_cat.name
+                target_cat.name = dialog.result
+                if self.app.db_manager.category_dao.update(target_cat):
+                    self.logger.info("カテゴリ '%s' を '%s' に変更しました (ID: %s)", old_name, dialog.result, target_cat.id)
+                self.refresh_categories()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"カテゴリの変更中にエラーが発生しました: {str(e)}", exc_info=True)
+
+    def delete_category(self) -> None:
+        try:
+            selection = self.cat_listbox.curselection()
+            if not selection or selection[0] == 0:
+                return
+
+            idx = selection[0]
+            target_cat = self.category_list[idx - 1]
+            cat_id = target_cat.id
+            if cat_id is None:
+                return
+
+            # セーフガード: カテゴリ内の定型文件数チェック
+            phrase_count = self.app.db_manager.category_dao.get_meta_phrase_count(cat_id)
+            if phrase_count > 0:
+                msg = self.app.translator("confirm_category_delete_msg").format(count=phrase_count)
+                confirm = messagebox.askyesno(
+                    self.app.translator("confirm_category_delete_title"),
+                    msg,
+                    parent=self
+                )
+                if not confirm:
+                    return
+
+            if self.app.db_manager.category_dao.delete(cat_id):
+                self.logger.info("カテゴリ '%s' (ID: %d) を削除しました", target_cat.name, cat_id)
+            self.selected_category_id = None
+            self.refresh_categories()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"カテゴリの削除中にエラーが発生しました: {str(e)}", exc_info=True)
 
     # ================= 定型文操作 =================
     def copy_selected_phrase(self) -> None:
-        selected = self.phrase_tree.selection()
-        if not selected:
-            return
+        try:
+            selected = self.phrase_tree.selection()
+            if not selected:
+                return
 
-        phrase_id = int(selected[0])
-        for phrase in self.phrase_list:
-            if phrase.id == phrase_id:
-                # システムクリップボードへコピー (履歴の最上位に移動＆通知表示)
-                self.app.monitor.update_clipboard(phrase.content)
-                break
+            phrase_id = int(selected[0])
+            for phrase in self.phrase_list:
+                if phrase.id == phrase_id:
+                    # システムクリップボードへコピー (履歴の最上位に移動＆通知表示)
+                    self.app.monitor.update_clipboard(phrase.content)
+                    self.logger.info("メタ定型文 '%s' (ID: %d) をクリップボードにコピーしました", phrase.title, phrase_id)
+                    break
+        except Exception as e:
+            self.log_and_show_error("エラー", f"定型文のコピー中にエラーが発生しました: {str(e)}", exc_info=True)
 
     def on_phrase_double_click(self, event: tk.Event) -> None:
         self.copy_selected_phrase()
 
     def add_phrase(self) -> None:
-        if not self.category_list:
-            messagebox.showerror("Error", "Please create at least one category first.", parent=self)
-            return
+        try:
+            if not self.category_list:
+                messagebox.showerror("Error", "Please create at least one category first.", parent=self)
+                return
 
-        dialog = MetaPhraseEditDialog(self, self.app, default_category_id=self.selected_category_id)
-        self.wait_window(dialog)
-        if dialog.result:
-            title, content, category_id = dialog.result
-            dto = MetaPhraseDTO(title=title, content=content, category_id=category_id, created_at=time.time())
-            self.app.db_manager.meta_phrase_dao.add(dto)
-            self.refresh_phrases()
+            dialog = MetaPhraseEditDialog(self, self.app, default_category_id=self.selected_category_id)
+            self.wait_window(dialog)
+            if dialog.result:
+                title, content, category_id = dialog.result
+                dto = MetaPhraseDTO(title=title, content=content, category_id=category_id, created_at=time.time())
+                new_id = self.app.db_manager.meta_phrase_dao.add(dto)
+                if new_id != -1:
+                    self.logger.info("メタ定型文 '%s' (ID: %d) を追加しました", title, new_id)
+                self.refresh_phrases()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"定型文の追加中にエラーが発生しました: {str(e)}", exc_info=True)
 
     def edit_phrase(self) -> None:
-        selected = self.phrase_tree.selection()
-        if not selected:
-            return
+        try:
+            selected = self.phrase_tree.selection()
+            if not selected:
+                return
 
-        phrase_id = int(selected[0])
-        target_phrase: MetaPhraseDTO | None = None
-        for phrase in self.phrase_list:
-            if phrase.id == phrase_id:
-                target_phrase = phrase
-                break
+            phrase_id = int(selected[0])
+            target_phrase: MetaPhraseDTO | None = None
+            for phrase in self.phrase_list:
+                if phrase.id == phrase_id:
+                    target_phrase = phrase
+                    break
 
-        if not target_phrase:
-            return
+            if not target_phrase:
+                return
 
-        dialog = MetaPhraseEditDialog(self, self.app, target_phrase)
-        self.wait_window(dialog)
-        if dialog.result:
-            title, content, category_id = dialog.result
-            target_phrase.title = title
-            target_phrase.content = content
-            target_phrase.category_id = category_id
-            self.app.db_manager.meta_phrase_dao.update(target_phrase)
-            self.refresh_phrases()
+            dialog = MetaPhraseEditDialog(self, self.app, target_phrase)
+            self.wait_window(dialog)
+            if dialog.result:
+                title, content, category_id = dialog.result
+                target_phrase.title = title
+                target_phrase.content = content
+                target_phrase.category_id = category_id
+                if self.app.db_manager.meta_phrase_dao.update(target_phrase):
+                    self.logger.info("メタ定型文 '%s' (ID: %d) を更新しました", title, phrase_id)
+                self.refresh_phrases()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"定型文の変更中にエラーが発生しました: {str(e)}", exc_info=True)
 
     def delete_phrase(self) -> None:
-        selected = self.phrase_tree.selection()
-        if not selected:
-            return
+        try:
+            selected = self.phrase_tree.selection()
+            if not selected:
+                return
 
-        phrase_id = int(selected[0])
-        self.app.db_manager.meta_phrase_dao.delete(phrase_id)
-        self.refresh_phrases()
+            phrase_id = int(selected[0])
+            target_phrase: MetaPhraseDTO | None = None
+            for phrase in self.phrase_list:
+                if phrase.id == phrase_id:
+                    target_phrase = phrase
+                    break
+
+            if self.app.db_manager.meta_phrase_dao.delete(phrase_id):
+                title = target_phrase.title if target_phrase else str(phrase_id)
+                self.logger.info("メタ定型文 '%s' (ID: %d) を削除しました", title, phrase_id)
+            self.refresh_phrases()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"定型文の削除中にエラーが発生しました: {str(e)}", exc_info=True)
 
     def show_context_menu(self, event: tk.Event) -> None:
         """右クリック時にコンテキストメニューを表示します。"""
-        clicked_idx = self.cat_listbox.nearest(event.y)
-        
-        # 項目がある場合のみ処理（無効な位置を右クリックした場合は選択を変えない）
-        bbox = self.cat_listbox.bbox(clicked_idx)
-        if bbox and event.y <= bbox[1] + bbox[3]:
-            self.cat_listbox.selection_clear(0, tk.END)
-            self.cat_listbox.selection_set(clicked_idx)
-            self.cat_listbox.activate(clicked_idx)
-            self.on_category_select() # 定型文リストの更新をトリガー
+        try:
+            clicked_idx = self.cat_listbox.nearest(event.y)
 
-            # [すべて] (インデックス0) では編集・削除を無効化
-            if clicked_idx == 0:
+            # 項目がある場合のみ処理（無効な位置を右クリックした場合は選択を変えない）
+            bbox = self.cat_listbox.bbox(clicked_idx)
+            if bbox and event.y <= bbox[1] + bbox[3]:
+                self.cat_listbox.selection_clear(0, tk.END)
+                self.cat_listbox.selection_set(clicked_idx)
+                self.cat_listbox.activate(clicked_idx)
+                self.on_category_select() # 定型文リストの更新をトリガー
+
+                # [すべて] (インデックス0) では編集・削除を無効化
+                if clicked_idx == 0:
+                    self.cat_menu.entryconfig(1, state="disabled")
+                    self.cat_menu.entryconfig(2, state="disabled")
+                else:
+                    self.cat_menu.entryconfig(1, state="normal")
+                    self.cat_menu.entryconfig(2, state="normal")
+            else:
+                # 項目外をクリックした場合は追加のみ有効
                 self.cat_menu.entryconfig(1, state="disabled")
                 self.cat_menu.entryconfig(2, state="disabled")
-            else:
-                self.cat_menu.entryconfig(1, state="normal")
-                self.cat_menu.entryconfig(2, state="normal")
-        else:
-            # 項目外をクリックした場合は追加のみ有効
-            self.cat_menu.entryconfig(1, state="disabled")
-            self.cat_menu.entryconfig(2, state="disabled")
 
-        self.cat_menu.tk_popup(event.x_root, event.y_root)
+            self.cat_menu.tk_popup(event.x_root, event.y_root)
+        except Exception as e:
+            self.log_and_show_error("エラー", f"コンテキストメニュー表示中にエラーが発生しました: {str(e)}", exc_info=True)
 
     # ================= 多言語対応 =================
     def on_language_changed(self, event: Any = None) -> None:
-        self.category_label.config(text=self.app.translator("meta_category_title"))
-        self.add_cat_btn.config(text=self.app.translator("add"))
-        self.edit_cat_btn.config(text=self.app.translator("edit"))
-        self.del_cat_btn.config(text=self.app.translator("delete"))
+        try:
+            self.category_label.config(text=self.app.translator("meta_category_title"))
+            self.add_cat_btn.config(text=self.app.translator("add"))
+            self.edit_cat_btn.config(text=self.app.translator("edit"))
+            self.del_cat_btn.config(text=self.app.translator("delete"))
 
-        # コンテキストメニューの再翻訳
-        self.cat_menu.entryconfig(0, label=self.app.translator("add_category"))
-        self.cat_menu.entryconfig(1, label=self.app.translator("edit_category"))
-        self.cat_menu.entryconfig(2, label=self.app.translator("delete_category"))
+            # コンテキストメニューの再翻訳
+            self.cat_menu.entryconfig(0, label=self.app.translator("add_category"))
+            self.cat_menu.entryconfig(1, label=self.app.translator("edit_category"))
+            self.cat_menu.entryconfig(2, label=self.app.translator("delete_category"))
 
-        self.phrase_label.config(text=self.app.translator("meta_phrase_title"))
-        self.phrase_tree.heading("title", text=self.app.translator("phrase_title_label"))
-        self.phrase_tree.heading("content", text=self.app.translator("phrase_content_label"))
+            self.phrase_label.config(text=self.app.translator("meta_phrase_title"))
+            self.phrase_tree.heading("title", text=self.app.translator("phrase_title_label"))
+            self.phrase_tree.heading("content", text=self.app.translator("phrase_content_label"))
 
-        self.copy_phrase_btn.config(text=self.app.translator("copy"))
-        self.add_phrase_btn.config(text=self.app.translator("add"))
-        self.edit_phrase_btn.config(text=self.app.translator("edit"))
-        self.del_phrase_btn.config(text=self.app.translator("delete"))
+            self.copy_phrase_btn.config(text=self.app.translator("copy"))
+            self.add_phrase_btn.config(text=self.app.translator("add"))
+            self.edit_phrase_btn.config(text=self.app.translator("edit"))
+            self.del_phrase_btn.config(text=self.app.translator("delete"))
 
-        self.refresh_categories()
+            self.refresh_categories()
+        except Exception as e:
+            self.log_and_show_error("エラー", f"言語の切り替え処理中にエラーが発生しました: {str(e)}", exc_info=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from src.core.event_dispatcher import EventDispatcher
+from src.core.history_service import HistoryService
+from src.db.database_manager import DatabaseManager
+
+
+@pytest.fixture
+def event_dispatcher() -> EventDispatcher:
+    """テスト用のクリーンな EventDispatcher インスタンスを提供します。"""
+    return EventDispatcher()
+
+
+@pytest.fixture
+def db_manager() -> Generator[DatabaseManager, None, None]:
+    """テスト用の一時的な SQLite DB ファイルを使用した DatabaseManager インスタンスを提供します。"""
+    import os
+    db_path = "test_temp_db.db"
+
+    if os.path.exists(db_path):
+        try:
+            os.remove(db_path)
+        except Exception:
+            pass
+
+    manager = DatabaseManager(db_path=db_path)
+    yield manager
+
+    # クリーンアップ
+    if os.path.exists(db_path):
+        try:
+            os.remove(db_path)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def history_service(db_manager: DatabaseManager, event_dispatcher: EventDispatcher) -> HistoryService:
+    """テスト用の HistoryService インスタンスを提供します（制限件数は5件に設定）。"""
+    return HistoryService(
+        db_manager=db_manager,
+        event_dispatcher=event_dispatcher,
+        history_limit=5
+    )

--- a/tests/test_history_service.py
+++ b/tests/test_history_service.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from typing import Any
+
+from src.core.event_dispatcher import EventDispatcher
+from src.core.history_service import HistoryService
+
+
+def test_initial_history_is_empty(history_service: HistoryService) -> None:
+    """初期化時点で履歴が空であることを検証します。"""
+    assert len(history_service.history) == 0
+    assert history_service.last_clipboard_data == ""
+
+
+def test_add_history_item(history_service: HistoryService, event_dispatcher: EventDispatcher) -> None:
+    """新しい履歴項目を追加した際の、状態更新とイベント通知を検証します。"""
+    event_data: dict[str, Any] = {}
+
+    def on_updated(data: dict[str, Any]) -> None:
+        nonlocal event_data
+        event_data = data
+
+    event_dispatcher.subscribe("HISTORY_UPDATED", on_updated)
+
+    # 項目追加
+    history_service.add_history_item("Hello World")
+
+    # 内部状態の検証
+    assert len(history_service.history) == 1
+    assert history_service.last_clipboard_data == "Hello World"
+    assert history_service.history[0][0] == "Hello World"
+    assert history_service.history[0][1] is False  # 初期状態はピン留め無し
+
+    # イベント通知の検証
+    assert event_data != {}
+    assert event_data["last_content"] == "Hello World"
+    assert len(event_data["history"]) == 1
+    assert event_data["history"][0][0] == "Hello World"
+
+
+def test_add_duplicate_item(history_service: HistoryService) -> None:
+    """連続した重複テキストの追加が無視されることを検証します。"""
+    history_service.add_history_item("Unique Item")
+    assert len(history_service.history) == 1
+
+    # 重複する項目を追加
+    history_service.add_history_item("Unique Item")
+    # 追加がスキップされていること
+    assert len(history_service.history) == 1
+
+
+def test_cleanup_limit(history_service: HistoryService) -> None:
+    """最大件数（このテストでは5件）を超えた際に古い履歴が自動削除されることを検証します。"""
+    for i in range(7):
+        history_service.add_history_item(f"Item {i}")
+
+    # 上限値5件に収まっていること
+    assert len(history_service.history) == 5
+    # 最新の5件（Item 2 〜 Item 6）が保持され、古い順に並んでいる（最新が先頭）
+    assert history_service.history[0][0] == "Item 6"
+    assert history_service.history[4][0] == "Item 2"
+
+
+def test_update_history_item(history_service: HistoryService) -> None:
+    """履歴項目の内容変更が正しくDBおよびメモリに反映されることを検証します。"""
+    history_service.add_history_item("Original Text")
+    item_id = history_service.history[0][2]
+
+    # コンテンツの変更
+    history_service.update_history_item_by_id(item_id, "Updated Text")
+
+    assert history_service.history[0][0] == "Updated Text"
+    assert history_service.last_clipboard_data == "Updated Text"
+
+
+def test_delete_history_item(history_service: HistoryService) -> None:
+    """履歴項目の削除が正しく機能することを検証します。"""
+    history_service.add_history_item("Item A")
+    history_service.add_history_item("Item B")
+    assert len(history_service.history) == 2
+
+    target_id = history_service.history[0][2]  # 最新の Item B
+    history_service.delete_history_item_by_id(target_id)
+
+    # 1件削除され、Item A だけが残る
+    assert len(history_service.history) == 1
+    assert history_service.history[0][0] == "Item A"
+    assert history_service.last_clipboard_data == "Item A"
+
+
+def test_pin_unpin_item(history_service: HistoryService) -> None:
+    """項目のピン留めおよびピン留め解除により、表示順序が正しく入れ替わることを検証します。"""
+    history_service.add_history_item("Normal 1")
+    history_service.add_history_item("Normal 2")
+    assert len(history_service.history) == 2
+
+    # 通常、最新の "Normal 2" が先頭 (インデックス0)
+    assert history_service.history[0][0] == "Normal 2"
+
+    # "Normal 1" の ID を取得してピン留め
+    target_id = history_service.history[1][2]
+    history_service.pin_item_by_id(target_id)
+
+    # get_history() はピン留めアイテムを先頭にして並べ替える
+    ordered_history = history_service.get_history()
+    assert ordered_history[0][0] == "Normal 1"
+    assert ordered_history[0][1] is True  # ピン留めフラグが True になっていること
+    assert ordered_history[1][0] == "Normal 2"
+
+    # ピン留めを解除
+    history_service.unpin_item_by_id(target_id)
+    ordered_history_after = history_service.get_history()
+    assert ordered_history_after[0][0] == "Normal 2"  # 通常の順序に戻る
+    assert ordered_history_after[0][1] is False
+    assert ordered_history_after[1][1] is False
+
+
+def test_clear_history(history_service: HistoryService) -> None:
+    """全履歴削除が正しく機能することを検証します。"""
+    history_service.add_history_item("Item 1")
+    history_service.add_history_item("Item 2")
+    assert len(history_service.history) == 2
+
+    history_service.clear_history()
+    assert len(history_service.history) == 0
+    assert history_service.last_clipboard_data == ""
+
+
+def test_delete_all_unpinned_history(history_service: HistoryService) -> None:
+    """ピン留めされていない項目のみが一括削除され、ピン留めされた項目が残ることを検証します。"""
+    history_service.add_history_item("Normal 1")
+    history_service.add_history_item("To be pinned")
+    history_service.add_history_item("Normal 2")
+
+    pin_id = history_service.history[1][2]  # "To be pinned"
+    history_service.pin_item_by_id(pin_id)
+
+    assert len(history_service.history) == 3
+
+    # ピン留めされていないものを一括削除
+    history_service.delete_all_unpinned_history()
+
+    # ピン留めしたアイテムだけが残る
+    assert len(history_service.history) == 1
+    assert history_service.history[0][0] == "To be pinned"
+    assert history_service.history[0][1] is True
+
+
+def test_import_history(history_service: HistoryService) -> None:
+    """テキストリストを一括インポートした際に、DBへ正しく追加され最大上限でクリーンアップされることを検証します。"""
+    import_data = ["Imported A", "Imported B", "Imported C", "Imported D", "Imported E", "Imported F"]
+
+    # 6件インポートするが上限は5件
+    history_service.import_history(import_data)
+
+    # 5件に収まっており、並び順が最新（リストの後ろ側）から順にインサートされていること
+    assert len(history_service.history) == 5
+    assert history_service.history[0][0] == "Imported F"
+    assert history_service.history[4][0] == "Imported B"
+
+
+def test_get_filtered_history(history_service: HistoryService) -> None:
+    """部分一致の検索フィルタリングが正しく機能することを検証します。"""
+    history_service.add_history_item("Apple")
+    history_service.add_history_item("Banana")
+    history_service.add_history_item("Pineapple")
+
+    # "apple" で検索（ケースインセンシティブかどうかはDAOの実装に依存するが、部分一致は動作する）
+    filtered = history_service.get_filtered_history("apple")
+
+    # Apple と Pineapple の 2件がマッチする
+    # ※ sqliteのLIKE検索はデフォルトで大文字小文字を区別しません
+    assert len(filtered) == 2
+    matched_contents = [item[0] for item in filtered]
+    assert "Apple" in matched_contents
+    assert "Pineapple" in matched_contents
+    assert "Banana" not in matched_contents
+
+
+def test_settings_changed(history_service: HistoryService, event_dispatcher: EventDispatcher) -> None:
+    """設定変更イベントによって制限件数が変更され、あふれた履歴がクリーンアップされることを検証します。"""
+    for i in range(5):
+        history_service.add_history_item(f"Item {i}")
+    assert len(history_service.history) == 5
+
+    # 設定変更イベントを発火（上限を3件に縮小）
+    event_dispatcher.dispatch("SETTINGS_CHANGED", {"history_limit": 3})
+
+    # 上限値が3に更新され、履歴があふれた分カットされていること
+    assert history_service.history_limit == 3
+    assert len(history_service.history) == 3
+    # 最新の3件が保持される
+    assert history_service.history[0][0] == "Item 4"
+    assert history_service.history[2][0] == "Item 2"


### PR DESCRIPTION
## 概要
アプリ全体のコード設計標準化および単一責任原則（SRP）の遵守に向けた全般的なリファクタリング（`refactor/general` ブランチ）を実施しました。
「疎結合なイベント駆動（Pub/Sub）モデルの完成」および「包括的なユニットテストインフラの新規構築」を完了しました。

## 変更内容
### 1. ユニットテストインフラの新規構築と包括的テストの追加
- **テスト自動生成/破棄フィクスチャ (`tests/conftest.py`)**:
  テストケースごとに自動的に作成・破棄される一時的なファイルベースの SQLite DB マネージャーを構築。既存の DAO 設計を壊すことなく、副作用のない安全で高速なテスト環境を整備しました。
- **包括的テストスイート (`tests/test_history_service.py`)**:
  `HistoryService` に対する CRUD、件数制限自動クリーンアップ、ピン留めソート、部分一致検索、およびイベント駆動の連動（イベントの受信と発火）を検証する 12 個のテストケースを追加。
- **インポート時の順序バグの修正**:
  一括インポート時にミリ秒単位の登録日時の重複による順序の不確定さを発見し、インサート順にわずかに秒数をずらすことで順序を完全に保証する修正を行いました。

### 2. UI とビジネスロジックの完全な「イベント駆動（Pub/Sub）」への移行
- **コールバック結合の完全排除**:
  `ClipboardMonitor` のポーリングループから直接 GUI を更新するために定義されていた `update_callback` および `_trigger_gui_update()` トリガーを完全に削除しました。
- **イベント購読の統合 (`src/core/app_main.py`)**:
  `MainApplication` が `EventDispatcher` の `HISTORY_UPDATED` イベントを直接購読するよう変更。`HistoryService` 側の状態変更が自律的にイベントを通じて GUI へ伝播する、理想的な疎結合アーキテクチャを実現しました。

### 3. クリップボード使用感不具合（UX）の解決と詳細レビュー資料の追加
- スクロールバーが強制リセットされる問題と、コピードラッグ選択時にフォーカスが失われる問題を調査した `review_2026_05_28_clipboard_ux_review.md`（Mermaidシーケンス図入り）を作成。
- 履歴リストボックスの「同一データ/テーマ描画スキップ」「再描画中のイベントガードフラグ」を実装。
- テキストエリアの「差分上書きチェック」および「ドラッグ選択中の自動上書き一時保留ガード」を実装。

## 品質担保
- 12個のテストケースが `pytest` で完全に合格 (100% Passed)。
- `ruff check --fix` および `mypy` による全ソースコード（`src`, `tests`）の厳格なコード規約と静的型チェックを完全にクリア。
