### PR TITLE
refactor(events) & fix: EventDispatcherの型安全化(#68)および各種不具合の修正(#66)

### DIFF
--- a/reusable_gui/core/events/event_dispatcher.py
+++ b/reusable_gui/core/events/event_dispatcher.py
@@ -7,6 +7,15 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _get_listener_name(listener: Callable[..., Any]) -> str:
+    """安全にリスナーの表示名を取得します（functools.partial や callable オブジェクト対応）。"""
+    if hasattr(listener, "__qualname__"):
+        return str(listener.__qualname__)
+    if hasattr(listener, "__name__"):
+        return str(listener.__name__)
+    return repr(listener)
+
+
 class EventDispatcher:
     """
     集中型イベントディスパッチャ。
@@ -49,6 +58,7 @@ class EventDispatcher:
             try:
                 listener(*args, **kwargs)
             except Exception:
+                listener_name = _get_listener_name(listener)
                 logger.error(
-                    f"Error dispatching event {event_type} to listener {getattr(listener, '__name__', str(listener))}: {traceback.format_exc()}"
+                    f"Error dispatching event {event_type} to listener {listener_name}: {traceback.format_exc()}"
                 )

--- a/src/core/clipboard/clipboard_monitor.py
+++ b/src/core/clipboard/clipboard_monitor.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import ctypes
 import ctypes.wintypes
 import logging
-import threading
-import time
 import tkinter as tk
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, cast
@@ -34,7 +32,8 @@ class ClipboardMonitor:
         self.notification_manager = NotificationManager(None) # 設定はイベント経由で渡されます
         self.error_callback: Callable[[str, str], None] | None = None
         self._running: bool = False
-        self.monitor_thread: threading.Thread | None = None
+        self._clipboard_check_job: str | None = None
+        self._auto_save_check_job: str | None = None
         self.history_file_path: str = history_file_path
         self.db_manager: DatabaseManager = db_manager
         self.history_service = history_service
@@ -114,18 +113,18 @@ class ClipboardMonitor:
         # _check_clipboardのロジックを模倣して、履歴を直接更新します
         self.history_service.add_history_item(text)
 
+    def _schedule_clipboard_check(self, delay_ms: int) -> None:
+        if self._running:
+            self._clipboard_check_job = self.tk_root.after(delay_ms, self._monitor_clipboard)
+
     def _monitor_clipboard(self) -> None:
-        logging.info("クリップボード監視を開始します")
-        while self._running:
-            try:
-                self.tk_root.after(0, self._check_clipboard)
-                time.sleep(0.5)
-            except RuntimeError as e:
-                logging.warning(f"Tkinterランタイムエラー: {e}")
-                time.sleep(1)
-            except Exception:
-                logging.error("クリップボード監視ループで予期せぬエラーが発生しました。", exc_info=True)
-                time.sleep(5)
+        """Checks the clipboard on the Tkinter main thread and schedules the next check."""
+        self._clipboard_check_job = None
+        if not self._running:
+            return
+
+        self._check_clipboard()
+        self._schedule_clipboard_check(500)
 
     def _decode_clipboard_data(self, data: Any) -> str:
         if isinstance(data, bytes):
@@ -230,24 +229,37 @@ class ClipboardMonitor:
     def start(self) -> None:
         if not self._running:
             self._running = True
-            self.monitor_thread = threading.Thread(target=self._monitor_clipboard, daemon=True) # type: ignore
-            self.monitor_thread.start() # type: ignore
+            logging.info("クリップボード監視を開始します")
+            self._schedule_clipboard_check(0)
             self._schedule_auto_save_check()
 
     def _schedule_auto_save_check(self) -> None:
         if self._running:
-            self.tk_root.after(self._auto_save_interval_ms, self._auto_save_check)
+            self._auto_save_check_job = self.tk_root.after(
+                self._auto_save_interval_ms, self._auto_save_check
+            )
 
     def _auto_save_check(self) -> None:
+        self._auto_save_check_job = None
         if not self._running:
             return
         # DBに都度保存しているため、ここでは何もしません
         self._schedule_auto_save_check()
 
+    def _cancel_scheduled_job(self, job_id: str | None) -> None:
+        if job_id is None:
+            return
+        try:
+            self.tk_root.after_cancel(job_id)
+        except tk.TclError:
+            pass
+
     def stop(self) -> None:
         self._running = False
-        if self.monitor_thread and self.monitor_thread.is_alive():
-            self.monitor_thread.join(timeout=2)
+        self._cancel_scheduled_job(self._clipboard_check_job)
+        self._cancel_scheduled_job(self._auto_save_check_job)
+        self._clipboard_check_job = None
+        self._auto_save_check_job = None
 
     def get_history(self) -> list[tuple[str, bool, float]]:
         return self.history_service.get_history()

--- a/src/core/config/settings_manager.py
+++ b/src/core/config/settings_manager.py
@@ -1,11 +1,14 @@
 import json
+import logging
 import os
-from typing import Any, cast
+from typing import Any
 
 from src.core.events.event_dispatcher import EventDispatcher
 from reusable_gui.core.config.schema import SettingField, WidgetType
 
 from . import defaults
+
+logger = logging.getLogger(__name__)
 
 
 class SettingsManager:
@@ -20,14 +23,78 @@ class SettingsManager:
         self.settings.update(loaded_settings)
         self.event_dispatcher.dispatch("SETTINGS_CHANGED", self.settings)
 
+    def _read_settings_file(self, filepath: str) -> dict[str, Any] | None:
+        """Reads a JSON settings object, returning None for invalid input."""
+        try:
+            with open(filepath, encoding="utf-8") as f:
+                loaded_settings = json.load(f)
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+            logger.warning("Could not read settings file %s: %s", filepath, error)
+            return None
+
+        if not isinstance(loaded_settings, dict):
+            logger.warning("Settings file %s must contain a JSON object.", filepath)
+            return None
+        return loaded_settings
+
+    def _is_valid_known_setting(self, key: str, value: Any) -> bool:
+        """Validates the type and bounds of built-in settings."""
+        if key == "theme":
+            return isinstance(value, str) and value in defaults.THEMES
+        if key == "history_limit":
+            return (
+                type(value) is int
+                and defaults.HISTORY_LIMIT_MIN <= value <= defaults.HISTORY_LIMIT_MAX
+            )
+        if key in {"clipboard_content_font_size", "history_font_size"}:
+            return type(value) is int and value > 0
+        if key == "excluded_apps":
+            return isinstance(value, list) and all(isinstance(app, str) for app in value)
+
+        default_value = defaults.DEFAULT_USER_SETTINGS[key]
+        if isinstance(default_value, bool):
+            return isinstance(value, bool)
+        if isinstance(default_value, int):
+            return type(value) is int
+        if isinstance(default_value, str):
+            return isinstance(value, str)
+        if isinstance(default_value, list):
+            return isinstance(value, list)
+        return type(value) is type(default_value)
+
+    def _validate_settings(
+        self, loaded_settings: dict[str, Any], *, reject_invalid: bool
+    ) -> dict[str, Any] | None:
+        """Keeps valid settings and optionally rejects an invalid import as a whole."""
+        validated_settings: dict[str, Any] = {}
+        invalid_keys: list[str] = []
+
+        for key, value in loaded_settings.items():
+            if key not in defaults.DEFAULT_USER_SETTINGS:
+                # Keep extension settings owned by plugins or newer application versions.
+                validated_settings[key] = value
+            elif self._is_valid_known_setting(key, value):
+                validated_settings[key] = value
+            else:
+                invalid_keys.append(key)
+
+        if invalid_keys:
+            logger.warning("Ignoring invalid settings: %s", ", ".join(invalid_keys))
+            if reject_invalid:
+                return None
+
+        return validated_settings
+
     def _load_settings(self) -> dict[str, Any]:
-        if os.path.exists(self.file_path):
-            with open(self.file_path, encoding="utf-8") as f:
-                try:
-                    return cast(dict[str, Any], json.load(f))
-                except json.JSONDecodeError:
-                    return {}
-        return {}
+        if not os.path.exists(self.file_path):
+            return {}
+
+        loaded_settings = self._read_settings_file(self.file_path)
+        if loaded_settings is None:
+            return {}
+
+        validated_settings = self._validate_settings(loaded_settings, reject_invalid=False)
+        return validated_settings if validated_settings is not None else {}
 
     def _get_default_settings(self) -> dict[str, Any]:
         return defaults.DEFAULT_USER_SETTINGS.copy()
@@ -53,28 +120,33 @@ class SettingsManager:
             json.dump(self.settings, f, ensure_ascii=False, indent=4)
 
     def load_settings_from_file(self, filepath: str) -> bool:
-        if os.path.exists(filepath):
-            with open(filepath, encoding="utf-8") as f:
-                try:
-                    loaded_settings = json.load(f)
-                    if "theme" in loaded_settings and "history_limit" in loaded_settings:
-                        self.settings.update(loaded_settings)
-                        self.event_dispatcher.dispatch("SETTINGS_CHANGED", self.settings)
-                        return True
-                except (json.JSONDecodeError, TypeError):
-                    return False
+        if not os.path.exists(filepath):
+            return False
+
+        loaded_settings = self._read_settings_file(filepath)
+        if loaded_settings is None:
+            return False
+
+        validated_settings = self._validate_settings(loaded_settings, reject_invalid=True)
+        if validated_settings is None:
+            return False
+
+        if "theme" in validated_settings and "history_limit" in validated_settings:
+            self.settings.update(validated_settings)
+            self.event_dispatcher.dispatch("SETTINGS_CHANGED", self.settings)
+            return True
         return False
 
     def get_settings_schema(self) -> list[SettingField]:
         """Clip Watcher の設定項目スキーマを返す。
 
-        タブ・グループ・ウィジェット種別を定義することで
-        SettingsWindow がUIを動的に生成する。
+        タブ・グループ・ウィジェット種別を定義することで、
+        SettingsWindow が UI を動的に生成できる。
         """
         d = defaults
 
         return [
-            # ── General / Appearance ───────────────────────────────────
+            # ── General / Appearance ─────────────────────────────────────────
             SettingField(
                 key="theme", label="Theme",
                 widget_type=WidgetType.OPTION_MENU,
@@ -88,7 +160,7 @@ class SettingsManager:
                 default="en", choices=["en", "ja"],
             ),
 
-            # ── General / Window Behavior ──────────────────────────────
+            # ── General / Window Behavior ────────────────────────────────────
             SettingField(
                 key="always_on_top", label="Always on Top",
                 widget_type=WidgetType.CHECKBUTTON,
@@ -96,7 +168,7 @@ class SettingsManager:
                 default=False,
             ),
 
-            # ── General / Startup ──────────────────────────────────────
+            # ── General / Startup ────────────────────────────────────────────
             SettingField(
                 key="startup_on_boot", label="Start with Windows",
                 widget_type=WidgetType.CHECKBUTTON,
@@ -104,7 +176,7 @@ class SettingsManager:
                 default=False,
             ),
 
-            # ── History ───────────────────────────────────────────────
+            # ── History ──────────────────────────────────────────────────────
             SettingField(
                 key="history_limit", label="History Limit",
                 widget_type=WidgetType.SPINBOX,
@@ -116,7 +188,7 @@ class SettingsManager:
                 width=10,
             ),
 
-            # ── Notifications / Behavior ───────────────────────────────
+            # ── Notifications / Behavior ─────────────────────────────────────
             SettingField(
                 key="notifications_enabled", label="Enable Notifications",
                 widget_type=WidgetType.CHECKBUTTON,
@@ -136,7 +208,7 @@ class SettingsManager:
                 default=False,
             ),
 
-            # ── Notifications / Content ────────────────────────────────
+            # ── Notifications / Content ──────────────────────────────────────
             SettingField(
                 key="notification_content_length", label="Notification Content Length",
                 widget_type=WidgetType.SPINBOX,
@@ -144,7 +216,7 @@ class SettingsManager:
                 default=50, min_value=10, max_value=200, increment=10, width=10,
             ),
 
-            # ── Font / Clipboard Content ───────────────────────────────
+            # ── Font / Clipboard Content ──────────────────────────────────────
             SettingField(
                 key="clipboard_content_font_family", label="Clipboard Content Font",
                 widget_type=WidgetType.FONT_PICKER,
@@ -158,7 +230,7 @@ class SettingsManager:
                 default=10, min_value=8, max_value=24, increment=1, width=5,
             ),
 
-            # ── Font / History ─────────────────────────────────────────
+            # ── Font / History ────────────────────────────────────────────────
             SettingField(
                 key="history_font_family", label="History Font",
                 widget_type=WidgetType.FONT_PICKER,
@@ -172,7 +244,7 @@ class SettingsManager:
                 default=10, min_value=8, max_value=24, increment=1, width=5,
             ),
 
-            # ── Excluded Apps ──────────────────────────────────────────
+            # ── Excluded Apps ─────────────────────────────────────────────────
             SettingField(
                 key="excluded_apps", label="Excluded Applications",
                 widget_type=WidgetType.LISTBOX_EDIT,

--- a/src/core/events/event_dispatcher.py
+++ b/src/core/events/event_dispatcher.py
@@ -2,40 +2,136 @@ import logging
 import traceback
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Any
+from typing import Any, Literal, overload
 
 from src.utils.error_handler import log_and_show_error
 
 logger = logging.getLogger(__name__)
+
+
+def _get_listener_name(listener: Callable[..., Any]) -> str:
+    """安全にリスナーの表示名を取得します（functools.partial や callable オブジェクト対応）。"""
+    if hasattr(listener, "__qualname__"):
+        return str(listener.__qualname__)
+    if hasattr(listener, "__name__"):
+        return str(listener.__name__)
+    return repr(listener)
+
 
 class EventDispatcher:
     """
     集中型イベントディスパッチャ。
     イベントの購読と発行を管理します。
     """
-    def __init__(self) -> None:
-        self._listeners: dict[str, list[Callable[[Any], None]]] = defaultdict(list)
 
-    def subscribe(self, event_type: str, listener: Callable[[Any], None]) -> None:
+    def __init__(self) -> None:
+        self._listeners: dict[str, list[Callable[..., Any]]] = defaultdict(list)
+
+    # ── Overloads for subscribe ─────────────────────────────────────────────
+    @overload
+    def subscribe(
+        self, event_type: Literal["SETTINGS_CHANGED"], listener: Callable[[dict[str, Any]], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self, event_type: Literal["HISTORY_UPDATED"], listener: Callable[[list[dict[str, Any]]], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self, event_type: Literal["LANGUAGE_CHANGED"], listener: Callable[[str], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self, event_type: Literal["HISTORY_ITEM_EDITED"], listener: Callable[[dict[str, Any]], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self,
+        event_type: Literal["REQUEST_UNDO_LAST_ACTION", "REQUEST_REDO_LAST_ACTION"],
+        listener: Callable[[], Any],
+    ) -> None: ...
+
+    @overload
+    def subscribe(self, event_type: str, listener: Callable[..., Any]) -> None: ...
+
+    def subscribe(self, event_type: str, listener: Callable[..., Any]) -> None:
         """
         指定されたイベントタイプにリスナーを登録します。
 
         Args:
             event_type (str): 購読するイベントのタイプ。
-            listener (Callable[[Any], None]): イベント発生時に呼び出される関数。
+            listener (Callable[..., Any]): イベント発生時に呼び出される関数。
         """
         self._listeners[event_type].append(listener)
 
-    def unsubscribe(self, event_type: str, listener: Callable[[Any], None]) -> None:
+    # ── Overloads for unsubscribe ───────────────────────────────────────────
+    @overload
+    def unsubscribe(
+        self, event_type: Literal["SETTINGS_CHANGED"], listener: Callable[[dict[str, Any]], Any]
+    ) -> None: ...
+
+    @overload
+    def unsubscribe(
+        self, event_type: Literal["HISTORY_UPDATED"], listener: Callable[[list[dict[str, Any]]], Any]
+    ) -> None: ...
+
+    @overload
+    def unsubscribe(
+        self, event_type: Literal["LANGUAGE_CHANGED"], listener: Callable[[str], Any]
+    ) -> None: ...
+
+    @overload
+    def unsubscribe(
+        self, event_type: Literal["HISTORY_ITEM_EDITED"], listener: Callable[[dict[str, Any]], Any]
+    ) -> None: ...
+
+    @overload
+    def unsubscribe(
+        self,
+        event_type: Literal["REQUEST_UNDO_LAST_ACTION", "REQUEST_REDO_LAST_ACTION"],
+        listener: Callable[[], Any],
+    ) -> None: ...
+
+    @overload
+    def unsubscribe(self, event_type: str, listener: Callable[..., Any]) -> None: ...
+
+    def unsubscribe(self, event_type: str, listener: Callable[..., Any]) -> None:
         """
         指定されたイベントタイプからリスナーの登録を解除します。
 
         Args:
             event_type (str): 登録解除するイベントのタイプ。
-            listener (Callable[[Any], None]): 登録解除する関数。
+            listener (Callable[..., Any]): 登録解除する関数。
         """
         if listener in self._listeners[event_type]:
             self._listeners[event_type].remove(listener)
+
+    # ── Overloads for dispatch ──────────────────────────────────────────────
+    @overload
+    def dispatch(self, event_type: Literal["SETTINGS_CHANGED"], payload: dict[str, Any]) -> None: ...
+
+    @overload
+    def dispatch(
+        self, event_type: Literal["HISTORY_UPDATED"], history_items: list[dict[str, Any]]
+    ) -> None: ...
+
+    @overload
+    def dispatch(self, event_type: Literal["LANGUAGE_CHANGED"], lang: str) -> None: ...
+
+    @overload
+    def dispatch(self, event_type: Literal["HISTORY_ITEM_EDITED"], item: dict[str, Any]) -> None: ...
+
+    @overload
+    def dispatch(
+        self, event_type: Literal["REQUEST_UNDO_LAST_ACTION", "REQUEST_REDO_LAST_ACTION"]
+    ) -> None: ...
+
+    @overload
+    def dispatch(self, event_type: str, *args: Any, **kwargs: Any) -> None: ...
 
     def dispatch(self, event_type: str, *args: Any, **kwargs: Any) -> None:
         """
@@ -50,5 +146,9 @@ class EventDispatcher:
             try:
                 listener(*args, **kwargs)
             except Exception:
-                # エラーハンドリングを強化することも可能
-                log_and_show_error("エラー",f"Error dispatching event {event_type} to listener {listener.__name__}: {traceback.format_exc()}", exc_info=True)
+                listener_name = _get_listener_name(listener)
+                log_and_show_error(
+                    "エラー",
+                    f"Error dispatching event {event_type} to listener {listener_name}: {traceback.format_exc()}",
+                    exc_info=True,
+                )

--- a/src/event_handlers/base_event_handler.py
+++ b/src/event_handlers/base_event_handler.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 if TYPE_CHECKING:
     from src.core.events.event_dispatcher import EventDispatcher
+
 
 class BaseEventHandler(ABC):
     """A base class for event handlers to standardize subscription and cleanup."""
@@ -27,6 +28,36 @@ class BaseEventHandler(ABC):
         """
         pass
 
+    @overload
+    def subscribe(
+        self, event_name: Literal["SETTINGS_CHANGED"], handler: Callable[[dict[str, Any]], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self, event_name: Literal["HISTORY_UPDATED"], handler: Callable[[list[dict[str, Any]]], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self, event_name: Literal["LANGUAGE_CHANGED"], handler: Callable[[str], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self, event_name: Literal["HISTORY_ITEM_EDITED"], handler: Callable[[dict[str, Any]], Any]
+    ) -> None: ...
+
+    @overload
+    def subscribe(
+        self,
+        event_name: Literal["REQUEST_UNDO_LAST_ACTION", "REQUEST_REDO_LAST_ACTION"],
+        handler: Callable[[], Any],
+    ) -> None: ...
+
+    @overload
+    def subscribe(self, event_name: str, handler: Callable[..., Any]) -> None: ...
+
     def subscribe(self, event_name: str, handler: Callable[..., Any]) -> None:
         """
         Subscribes a handler to an event and tracks the subscription.
@@ -48,3 +79,4 @@ class BaseEventHandler(ABC):
             if hasattr(self.dispatcher, 'unsubscribe'):
                 self.dispatcher.unsubscribe(event_name, handler)
         self._subscriptions = []
+

--- a/src/event_handlers/history_handlers.py
+++ b/src/event_handlers/history_handlers.py
@@ -208,7 +208,7 @@ class HistoryEventHandlers(BaseEventHandler):
 
             selected_index: int = selected_indices[0]
 
-            history_data: list[tuple[str, bool, float]] = history_component.history # type: ignore
+            history_data: list[tuple[str, bool, float]] = history_component.displayed_history
             if 0 <= selected_index < len(history_data):
                 original_text: str = history_data[selected_index][0]
                 item_id: float = history_data[selected_index][2] # Get item_id

--- a/src/gui/main_gui.py
+++ b/src/gui/main_gui.py
@@ -79,7 +79,7 @@ class ClipWatcherGUI(BaseFrameGUI):
         self.control_frame = ttk.Frame(history_area_frame)
         self.control_frame.pack(pady=config.FRAME_PADDING)
 
-        self.copy_history_button = ttk.Button(self.control_frame, text="", command=lambda: self.app.event_dispatcher.dispatch("HISTORY_COPY_SELECTED", self.history_component.listbox.curselection())) # type: ignore
+        self.copy_history_button = ttk.Button(self.control_frame, text="", command=lambda: self.app.event_dispatcher.dispatch("HISTORY_COPY_SELECTED", self.history_component.get_ids_for_indices(self.history_component.listbox.curselection()))) # type: ignore
         self.copy_history_button.pack(side=tk.LEFT, padx=config.BUTTON_PADDING_X)
 
         self.sort_button = ttk.Button(self.control_frame, text="", command=lambda: self.app.event_dispatcher.dispatch("HISTORY_TOGGLE_SORT")) # type: ignore
@@ -258,15 +258,18 @@ class ClipWatcherGUI(BaseFrameGUI):
             unpinned.reverse()
             history = pinned + unpinned
 
-        self.history_data = history
         search_query: str = self.search_entry.get() if hasattr(self, 'search_entry') else ""
         theme_name: str = self.app.theme_manager.get_current_theme() # type: ignore
         theme = THEMES.get(theme_name, THEMES['light'])
         if search_query:
-            filtered_history: list[tuple[str, bool, float]] = self.app.monitor.get_filtered_history(search_query) # type: ignore
-            self.history_component.update_history(filtered_history, theme)
+            displayed_history: list[tuple[str, bool, float]] = self.app.monitor.get_filtered_history(search_query) # type: ignore
         else:
-            self.history_component.update_history(history, theme)
+            displayed_history = history
+
+        # 選択・編集対象の解決は必ず「実際に表示中のリスト」と一致させる
+        # （検索フィルタ適用中は self.history_data も filtered_history と揃える）
+        self.history_data = displayed_history
+        self.history_component.update_history(displayed_history, theme)
 
         # テキストエリアの上書き防止（差分チェックおよび選択操作状態の保護）
         selected_indices: tuple[int, ...] = self.history_component.listbox.curselection()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,7 +41,7 @@ def test_settings_manager_load_and_save(event_dispatcher: EventDispatcher, temp_
 
     # 2. 値の書き換えとセーブ
     manager.set_setting("history_limit", 15)
-    manager.set_setting("theme", "DarkBlue")
+    manager.set_setting("theme", "dark")
     manager.save_settings()
 
     # ファイルが正しく生成されていること
@@ -51,7 +51,7 @@ def test_settings_manager_load_and_save(event_dispatcher: EventDispatcher, temp_
     new_manager = SettingsManager(event_dispatcher=event_dispatcher, file_path=temp_settings_file)
     new_manager.load_and_notify()
     assert new_manager.get_setting("history_limit") == 15
-    assert new_manager.get_setting("theme") == "DarkBlue"
+    assert new_manager.get_setting("theme") == "dark"
 
 
 def test_settings_manager_event_trigger(event_dispatcher: EventDispatcher, temp_settings_file: str) -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -44,6 +44,105 @@ def test_event_dispatcher_unsubscribe(event_dispatcher: EventDispatcher) -> None
     assert call_count == 1
 
 
+def test_event_dispatcher_variadic_listeners(event_dispatcher: EventDispatcher) -> None:
+    """引数なし、複数位置引数、キーワード引数を伴うリスナーの正常呼び出しを検証します。"""
+    no_arg_called = False
+    multi_arg_result: tuple[int, str] | None = None
+    kw_arg_result: str | None = None
+
+    def no_arg_listener() -> None:
+        nonlocal no_arg_called
+        no_arg_called = True
+
+    def multi_arg_listener(a: int, b: str) -> None:
+        nonlocal multi_arg_result
+        multi_arg_result = (a, b)
+
+    def kw_arg_listener(*, name: str) -> None:
+        nonlocal kw_arg_result
+        kw_arg_result = name
+
+    event_dispatcher.subscribe("NO_ARG_EVENT", no_arg_listener)
+    event_dispatcher.dispatch("NO_ARG_EVENT")
+    assert no_arg_called is True
+
+    event_dispatcher.subscribe("MULTI_ARG_EVENT", multi_arg_listener)
+    event_dispatcher.dispatch("MULTI_ARG_EVENT", 42, "hello")
+    assert multi_arg_result == (42, "hello")
+
+    event_dispatcher.subscribe("KW_ARG_EVENT", kw_arg_listener)
+    event_dispatcher.dispatch("KW_ARG_EVENT", name="clip_watcher")
+    assert kw_arg_result == "clip_watcher"
+
+
+def test_event_dispatcher_safe_error_logging_with_partial_and_callable_object(
+    event_dispatcher: EventDispatcher, monkeypatch: Any
+) -> None:
+    """functools.partialやcallableオブジェクトの例外発生時も安全にエラーログ出力が行われることを検証します。"""
+    import functools
+
+    logged_errors: list[str] = []
+
+    def mock_log_and_show_error(title: str, message: str, exc_info: bool = False) -> None:
+        logged_errors.append(message)
+
+    monkeypatch.setattr("src.core.events.event_dispatcher.log_and_show_error", mock_log_and_show_error)
+
+    # 1. functools.partial の例
+    def failing_target(arg: str) -> None:
+        raise ValueError("Partial target failure")
+
+    partial_listener = functools.partial(failing_target, "test")
+    event_dispatcher.subscribe("PARTIAL_FAIL_EVENT", partial_listener)
+    event_dispatcher.dispatch("PARTIAL_FAIL_EVENT")
+
+    assert len(logged_errors) == 1
+    assert "ValueError: Partial target failure" in logged_errors[0]
+
+    # 2. __name__ を持たない Callable クラスインスタンスの例
+    class CustomCallableListener:
+        def __call__(self) -> None:
+            raise RuntimeError("Callable object failure")
+
+    callable_listener = CustomCallableListener()
+    event_dispatcher.subscribe("CALLABLE_FAIL_EVENT", callable_listener)
+    event_dispatcher.dispatch("CALLABLE_FAIL_EVENT")
+
+    assert len(logged_errors) == 2
+    assert "RuntimeError: Callable object failure" in logged_errors[1]
+
+
+def test_event_dispatcher_event_contracts(event_dispatcher: EventDispatcher) -> None:
+    """SETTINGS_CHANGED, HISTORY_UPDATED, LANGUAGE_CHANGED などの主要イベント契約を検証します。"""
+    settings_received: dict[str, Any] = {}
+    history_received: list[dict[str, Any]] = []
+    lang_received: str = ""
+
+    def on_settings(payload: dict[str, Any]) -> None:
+        nonlocal settings_received
+        settings_received = payload
+
+    def on_history(items: list[dict[str, Any]]) -> None:
+        nonlocal history_received
+        history_received = items
+
+    def on_lang(lang: str) -> None:
+        nonlocal lang_received
+        lang_received = lang
+
+    event_dispatcher.subscribe("SETTINGS_CHANGED", on_settings)
+    event_dispatcher.subscribe("HISTORY_UPDATED", on_history)
+    event_dispatcher.subscribe("LANGUAGE_CHANGED", on_lang)
+
+    event_dispatcher.dispatch("SETTINGS_CHANGED", {"theme": "dark"})
+    event_dispatcher.dispatch("HISTORY_UPDATED", [{"id": 1, "content": "text"}])
+    event_dispatcher.dispatch("LANGUAGE_CHANGED", "ja")
+
+    assert settings_received == {"theme": "dark"}
+    assert history_received == [{"id": 1, "content": "text"}]
+    assert lang_received == "ja"
+
+
 # ==========================================
 # UndoManager Tests (3 Items)
 # ==========================================


### PR DESCRIPTION
## 概要
Issue #68 (`EventDispatcher` の型定義見直しとイベント契約明示化) および Issue #66 (設定検証・GUI選択・Tkinterメインスレッド監視等の不具合修正) の対応です。

Closes #68
Closes #66

## 変更点

### 1. EventDispatcher の型安全化および実装改修 (Issue #68)
- `EventDispatcher` のリスナー登録型を `Callable[..., Any]` に対応し、引数なし・複数位置引数・キーワード引数を柔軟かつ安全に受領できるよう改修。
- `_get_listener_name()` ヘルパー関数を追加し、`functools.partial` や `__name__` を持たない callable オブジェクトの例外発生時にも `AttributeError` にならず安全にエラーログ出力されるよう保護。
- `@overload` を導入し、主要イベント（`SETTINGS_CHANGED`, `HISTORY_UPDATED`, `LANGUAGE_CHANGED`, `HISTORY_ITEM_EDITED`, `REQUEST_UNDO_LAST_ACTION`, `REQUEST_REDO_LAST_ACTION` 等）の引数型契約を明示化（mypyでの型検証が可能に）。
- `BaseEventHandler.subscribe()` にも `@overload` を引き継ぎ。

### 2. 各種不具合の修正および改善 (Issue #66)
- `fix(clipboard)`: Tkinter メインスレッドで監視処理を実行するよう修正。
- `fix(config)`: 設定ファイル読み込み時の型・境界値バリデーション処理を強化。
- `fix(history)`: プラグイン変換時の履歴参照エラーを修正。
- `fix(gui)`: 検索中の履歴選択およびコピー対象を正しく解決。
- `test(config)`: 設定検証強化に伴い、テストコード内のテーマ指定を有効値（`'dark'`）に更新。

## 検証結果
- `pytest`: 43件中43件すべてのテストが正常に通過 (100% Pass)
- `mypy src`: 型エラー 0件 (Success)
